### PR TITLE
use pool address for Pools primary ID

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -17,6 +17,7 @@ enum PoolType {
 
 type Pool @entity {
   id: ID!
+  poolId: Bytes!
   address: Bytes!
   poolType: PoolType
   factory: Bytes
@@ -41,10 +42,10 @@ type Pool @entity {
 
   tokensList: [Bytes!]!
 
-  tokens: [PoolToken!] @derivedFrom(field: "poolId")
-  swaps: [Swap!] @derivedFrom(field: "poolId")
-  shares: [PoolShare!] @derivedFrom(field: "poolId")
-  historicalValues: [PoolHistoricalLiquidity!] @derivedFrom(field: "poolId")
+  tokens: [PoolToken!] @derivedFrom(field: "poolAddress")
+  swaps: [Swap!] @derivedFrom(field: "poolAddress")
+  shares: [PoolShare!] @derivedFrom(field: "poolAddress")
+  historicalValues: [PoolHistoricalLiquidity!] @derivedFrom(field: "poolAddress")
 
   # StablePool Only
   amp: BigInt
@@ -58,7 +59,7 @@ type Pool @entity {
 
 type PoolToken @entity {
   id: ID!
-  poolId: Pool!
+  poolAddress: Pool!
   symbol: String
   name: String
   decimals: Int!
@@ -74,7 +75,7 @@ type PoolToken @entity {
 type PoolShare @entity {
   id: ID!
   userAddress: User!
-  poolId: Pool!
+  poolAddress: Pool!
   balance: BigDecimal!
 }
 
@@ -101,7 +102,7 @@ type Swap @entity {
   tokenOutSym: String!
   tokenAmountIn: BigDecimal!
   tokenAmountOut: BigDecimal!
-  poolId: Pool!
+  poolAddress: Pool!
   userAddress: User!
   timestamp: Int!
   tx: Bytes!
@@ -127,14 +128,14 @@ type LatestPrice @entity {
   id: ID!
   asset: Bytes!
   pricingAsset: Bytes! # address of stable asset
-  poolId: Pool! # last pool which set price
+  poolAddress: Pool! # last pool which set price
   price:  BigDecimal! # all the latest prices
   block: BigInt! # last block that prices were updated
 }
 
 type PoolHistoricalLiquidity @entity {
   id: ID!
-  poolId: Pool!
+  poolAddress: Pool!
   poolTotalShares: BigDecimal!
   poolLiquidity: BigDecimal! # total value, priced in the stable asset - ie USD
   poolShareValue: BigDecimal!
@@ -143,8 +144,8 @@ type PoolHistoricalLiquidity @entity {
 }
 
 type TokenPrice @entity {
-  id: ID! # address of token + address of stablecoin-poolId
-  poolId: Pool!
+  id: ID! # address of token + address of stablecoin-poolAddress
+  poolAddress: Pool!
   asset: Bytes!
   amount: BigDecimal!
   pricingAsset: Bytes! # address of stable asset

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -1,7 +1,5 @@
 import { BigInt } from '@graphprotocol/graph-ts';
 import { Transfer } from '../types/templates/WeightedPool/BalancerPoolToken';
-import { WeightedPool } from '../types/templates/WeightedPool/WeightedPool';
-import { ConvergentCurvePool } from '../types/templates/ConvergentCurvePool/ConvergentCurvePool';
 
 import { PoolShare, Pool } from '../types/schema';
 import { tokenToDecimal, createPoolShareEntity, getPoolShareId } from './helpers';
@@ -14,11 +12,7 @@ import { ZERO_ADDRESS, ZERO_BD } from './constants';
 export function handleTransfer(event: Transfer): void {
   let poolAddress = event.address;
 
-  // TODO - refactor so pool -> poolId doesn't require call
-  let poolContract = WeightedPool.bind(poolAddress);
-
-  let poolIdCall = poolContract.try_getPoolId();
-  let poolId = poolIdCall.value;
+  let pool = Pool.load(poolAddress.toHexString()) as Pool;
 
   let isMint = event.params.from.toHex() == ZERO_ADDRESS;
   let isBurn = event.params.to.toHex() == ZERO_ADDRESS;
@@ -30,8 +24,6 @@ export function handleTransfer(event: Transfer): void {
   let poolShareToId = getPoolShareId(poolAddress, event.params.to);
   let poolShareTo = PoolShare.load(poolShareToId);
   let poolShareToBalance = poolShareTo == null ? ZERO_BD : poolShareTo.balance;
-
-  let pool = Pool.load(poolId.toHexString()) as Pool;
 
   let BPT_DECIMALS = 18;
 
@@ -81,11 +73,7 @@ export function handleTransfer(event: Transfer): void {
 export function handleTransferCCP(event: Transfer): void {
   let poolAddress = event.address;
 
-  // TODO - refactor so pool -> poolId doesn't require call
-  let poolContract = ConvergentCurvePool.bind(poolAddress);
-
-  let poolIdCall = poolContract.try_getPoolId();
-  let poolId = poolIdCall.value;
+  let pool = Pool.load(poolAddress.toHexString()) as Pool;
 
   let isMint = event.params.from.toHex() == ZERO_ADDRESS;
   let isBurn = event.params.to.toHex() == ZERO_ADDRESS;
@@ -97,8 +85,6 @@ export function handleTransferCCP(event: Transfer): void {
   let poolShareToId = getPoolShareId(poolAddress, event.params.to);
   let poolShareTo = PoolShare.load(poolShareToId);
   let poolShareToBalance = poolShareTo == null ? ZERO_BD : poolShareTo.balance;
-
-  let pool = Pool.load(poolId.toHexString()) as Pool;
 
   let BPT_DECIMALS = 18;
 

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -47,12 +47,12 @@ export function handleNewWeightedPool(event: PoolCreated): void {
       let tokenAddress = tokens[i];
       let weight = weights[i];
 
-      let poolTokenId = getPoolTokenId(poolId.toHexString(), tokenAddress);
+      let poolTokenId = getPoolTokenId(poolAddress, tokenAddress);
 
       if (tokensList.indexOf(tokenAddress) == -1) {
         tokensList.push(tokenAddress);
       }
-      createPoolTokenEntity(poolId.toHexString(), tokenAddress);
+      createPoolTokenEntity(poolAddress, tokenAddress);
       let poolToken = PoolToken.load(poolTokenId);
       poolToken.weight = scaleDown(weight, 18);
       poolToken.save();
@@ -96,12 +96,12 @@ export function handleNewStablePool(event: PoolCreated): void {
     for (let i: i32 = 0; i < tokens.length; i++) {
       let tokenAddress = tokens[i];
 
-      let poolTokenId = getPoolTokenId(poolId.toHexString(), tokenAddress);
+      let poolTokenId = getPoolTokenId(poolAddress, tokenAddress);
 
       if (tokensList.indexOf(tokenAddress) == -1) {
         tokensList.push(tokenAddress);
       }
-      createPoolTokenEntity(poolId.toHexString(), tokenAddress);
+      createPoolTokenEntity(poolAddress, tokenAddress);
       let poolToken = PoolToken.load(poolTokenId);
 
       poolToken.save();
@@ -163,12 +163,12 @@ export function handleNewCCPPool(event: PoolCreated): void {
     for (let i: i32 = 0; i < tokens.length; i++) {
       let tokenAddress = tokens[i];
 
-      let poolTokenId = getPoolTokenId(poolId.toHexString(), tokenAddress);
+      let poolTokenId = getPoolTokenId(poolAddress, tokenAddress);
 
       if (tokensList.indexOf(tokenAddress) == -1) {
         tokensList.push(tokenAddress);
       }
-      createPoolTokenEntity(poolId.toHexString(), tokenAddress);
+      createPoolTokenEntity(poolAddress, tokenAddress);
       let poolToken = PoolToken.load(poolTokenId);
       poolToken.save();
     }
@@ -198,9 +198,9 @@ function handleNewPool(event: PoolCreated, poolId: Bytes, swapFee: BigInt): Pool
 
   let poolAddress: Address = event.params.pool;
 
-  let pool = Pool.load(poolId.toHexString());
+  let pool = Pool.load(poolAddress.toHexString());
   if (pool == null) {
-    pool = newPoolEntity(poolId.toHexString());
+    pool = newPoolEntity(poolAddress.toHexString(), poolId);
 
     pool.swapFee = scaleDown(swapFee, 18);
     pool.createTime = event.block.timestamp.toI32();

--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -11,16 +11,16 @@ export function isPricingAsset(asset: Address): boolean {
   return false;
 }
 
-export function updatePoolLiquidity(poolId: string, block: BigInt, pricingAsset: Address): void {
-  let pool = Pool.load(poolId);
+export function updatePoolLiquidity(poolAddress: Address, block: BigInt, pricingAsset: Address): void {
+  let pool = Pool.load(poolAddress.toHexString());
   if (pool == null) return;
 
   let tokensList: Bytes[] = pool.tokensList;
   if (tokensList.length < 2) return;
 
-  let phlId = getPoolHistoricalLiquidityId(poolId, pricingAsset, block);
+  let phlId = getPoolHistoricalLiquidityId(poolAddress, pricingAsset, block);
   let phl = new PoolHistoricalLiquidity(phlId);
-  phl.poolId = poolId;
+  phl.poolAddress = poolAddress.toHexString();
   phl.pricingAsset = pricingAsset;
   phl.block = block;
   phl.poolTotalShares = pool.totalShares;
@@ -30,7 +30,7 @@ export function updatePoolLiquidity(poolId: string, block: BigInt, pricingAsset:
   for (let j: i32 = 0; j < tokensList.length; j++) {
     let tokenAddress: Address = Address.fromString(tokensList[j].toHexString());
 
-    let poolTokenId: string = getPoolTokenId(poolId, tokenAddress);
+    let poolTokenId: string = getPoolTokenId(poolAddress, tokenAddress);
     let poolToken = PoolToken.load(poolTokenId);
 
     if (tokenAddress == pricingAsset) {
@@ -40,7 +40,7 @@ export function updatePoolLiquidity(poolId: string, block: BigInt, pricingAsset:
     let poolTokenQuantity: BigDecimal = poolToken.balance;
 
     // compare any new token price with the last price
-    let tokenPriceId = getTokenPriceId(poolId, tokenAddress, pricingAsset, block);
+    let tokenPriceId = getTokenPriceId(poolAddress, tokenAddress, pricingAsset, block);
     let tokenPrice = TokenPrice.load(tokenPriceId);
     let price: BigDecimal;
     let latestPriceId = getLatestPriceId(tokenAddress, pricingAsset);
@@ -63,7 +63,7 @@ export function updatePoolLiquidity(poolId: string, block: BigInt, pricingAsset:
       }
       latestPrice.price = price;
       latestPrice.block = block;
-      latestPrice.poolId = poolId;
+      latestPrice.poolAddress = poolAddress.toHexString();
       latestPrice.save();
     }
     if (price) {
@@ -115,8 +115,8 @@ function getLatestPriceId(tokenAddress: Address, pricingAsset: Address): string 
   return tokenAddress.toHexString().concat('-').concat(pricingAsset.toHexString());
 }
 
-function getPoolHistoricalLiquidityId(poolId: string, tokenAddress: Address, block: BigInt): string {
-  return poolId.concat('-').concat(tokenAddress.toHexString()).concat('-').concat(block.toString());
+function getPoolHistoricalLiquidityId(poolAddress: Address, tokenAddress: Address, block: BigInt): string {
+  return poolAddress.toHexString().concat('-').concat(tokenAddress.toHexString()).concat('-').concat(block.toString());
 }
 
 function isUSDStable(asset: Address): boolean {


### PR DESCRIPTION
Makes a pool`s address the primary key for a pool to speed indexing and simplify

Must be merged simultaneously with frontend changes