### PR TITLE
handle swap fee change events

### DIFF
--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -1,11 +1,29 @@
 import { BigInt } from '@graphprotocol/graph-ts';
 import { Transfer } from '../types/templates/WeightedPool/BalancerPoolToken';
-import { WeightedPool } from '../types/templates/WeightedPool/WeightedPool';
+import { WeightedPool, SwapFeePercentageChanged } from '../types/templates/WeightedPool/WeightedPool';
 import { ConvergentCurvePool } from '../types/templates/ConvergentCurvePool/ConvergentCurvePool';
 
 import { PoolShare, Pool } from '../types/schema';
-import { tokenToDecimal, createPoolShareEntity, getPoolShareId } from './helpers';
+import { tokenToDecimal, createPoolShareEntity, getPoolShareId, scaleDown } from './helpers';
 import { ZERO_ADDRESS, ZERO_BD } from './constants';
+
+/************************************
+ *********** SWAP FEES ************
+ ************************************/
+
+ export function handleSwapFeePercentageChange(event: SwapFeePercentageChanged): void {
+  let poolAddress = event.address;
+
+  // TODO - refactor so pool -> poolId doesn't require call
+  let poolContract = WeightedPool.bind(poolAddress);
+  let poolIdCall = poolContract.try_getPoolId();
+  let poolId = poolIdCall.value;
+
+  let pool = Pool.load(poolId.toHexString()) as Pool;
+
+  pool.swapFee = scaleDown(event.swapFeePercentage, 18);
+  pool.save();
+}
 
 /************************************
  *********** POOL SHARES ************

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -11,7 +11,7 @@ import { ZERO_ADDRESS, ZERO_BD } from './constants';
  *********** SWAP FEES ************
  ************************************/
 
- export function handleSwapFeePercentageChange(event: SwapFeePercentageChanged): void {
+export function handleSwapFeePercentageChange(event: SwapFeePercentageChanged): void {
   let poolAddress = event.address;
 
   // TODO - refactor so pool -> poolId doesn't require call
@@ -21,7 +21,7 @@ import { ZERO_ADDRESS, ZERO_BD } from './constants';
 
   let pool = Pool.load(poolId.toHexString()) as Pool;
 
-  pool.swapFee = scaleDown(event.swapFeePercentage, 18);
+  pool.swapFee = scaleDown(event.params.swapFeePercentage, 18);
   pool.save();
 }
 

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -167,6 +167,8 @@ templates:
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
+        - event: SwapFeePercentageChanged(uint256)
+          handler: handleSwapFeePercentageChange
   - kind: ethereum/contract
     name: StablePool
     network: mainnet
@@ -190,6 +192,8 @@ templates:
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
+        - event: SwapFeePercentageChanged(uint256)
+          handler: handleSwapFeePercentageChange
   - kind: ethereum/contract
     name: ConvergentCurvePool
     network: mainnet


### PR DESCRIPTION
fixes #82 
Local test using the [beta subgraph](https://thegraph.com/explorer/subgraph/balancer-labs/balancer-beta-v2?version=current) compared to production: same 24h volume, 24h fees in the local test match the 0.35% the pool is set to, whereas 24h fees in production adds up to the 0.4% the pool was initially deployed with
![image](https://user-images.githubusercontent.com/34865315/123816397-a995e380-d8cd-11eb-919d-bccc346ce23f.png)
