### PR TITLE
Changes for new Stable pool factory.

### DIFF
--- a/abis/StablePool.json
+++ b/abis/StablePool.json
@@ -54,6 +54,50 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "startValue",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "endValue",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "startTime",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "endTime",
+        "type": "uint256"
+      }
+    ],
+    "name": "AmpUpdateStarted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "currentValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "AmpUpdateStopped",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": true,
         "internalType": "address",
         "name": "owner",
@@ -216,7 +260,7 @@
         "type": "uint8"
       }
     ],
-    "stateMutability": "pure",
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -232,7 +276,7 @@
         "type": "uint256"
       }
     ],
-    "name": "decreaseApproval",
+    "name": "decreaseAllowance",
     "outputs": [
       {
         "internalType": "bool",
@@ -268,7 +312,17 @@
     "outputs": [
       {
         "internalType": "uint256",
-        "name": "",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "isUpdating",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "precision",
         "type": "uint256"
       }
     ],
@@ -385,11 +439,11 @@
       },
       {
         "internalType": "uint256",
-        "name": "amount",
+        "name": "addedValue",
         "type": "uint256"
       }
     ],
-    "name": "increaseApproval",
+    "name": "increaseAllowance",
     "outputs": [
       {
         "internalType": "bool",
@@ -624,6 +678,82 @@
   {
     "inputs": [
       {
+        "components": [
+          {
+            "internalType": "enum IVault.SwapKind",
+            "name": "kind",
+            "type": "uint8"
+          },
+          {
+            "internalType": "contract IERC20",
+            "name": "tokenIn",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IERC20",
+            "name": "tokenOut",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "poolId",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lastChangeBlock",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "from",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "userData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IPoolSwapStructs.SwapRequest",
+        "name": "request",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint256",
+        "name": "balanceTokenIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "balanceTokenOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "onSwap",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "address",
         "name": "owner",
         "type": "address"
@@ -715,7 +845,7 @@
         "type": "uint256[]"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -769,7 +899,25 @@
         "type": "uint256[]"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "poolConfig",
+        "type": "bytes"
+      }
+    ],
+    "name": "setAssetManagerPoolConfig",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -794,6 +942,31 @@
       }
     ],
     "name": "setSwapFeePercentage",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "rawEndValue",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "endTime",
+        "type": "uint256"
+      }
+    ],
+    "name": "startAmplificationParameterUpdate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stopAmplificationParameterUpdate",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -108,7 +108,9 @@ export function handleNewStablePool(event: PoolCreated): void {
     }
 
     let ampCall = poolContract.try_getAmplificationParameter();
-    let amp = ampCall.value;
+    let value = ampCall.value.value0;
+    let precision = ampCall.value.value2;
+    let amp = value.div(precision);
     pool.amp = amp;
 
     pool.tokensList = tokensList;

--- a/subgraph.kovan.yaml
+++ b/subgraph.kovan.yaml
@@ -97,7 +97,7 @@ dataSources:
     name: StablePoolFactory
     network: kovan
     source:
-      address: '0xA9B3f46761F3A47056F39724FB5D9560f3629fB8'
+      address: '0x751dfDAcE1AD995fF13c927f6f761C6604532c79'
       abi: StablePoolFactory
       startBlock: 25266622
     mapping:

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -124,7 +124,7 @@ dataSources:
     #name: StablePoolFactory
     #network: mainnet
     #source:
-      #address: '0xaD9a0de4fda03eE4cdb07590B42D6469Ad1aBd85'
+      #address: '0xc66Ba2B6595D3613CCab350C886aCE23866EDe24'
       #abi: StablePoolFactory
       #startBlock: 12272146
     #mapping:


### PR DESCRIPTION
- Updated StablePool ABI to latest.
- Get amplification factor using new method with precision.
- Update Kovan and Mainnet StablePoolFactory addresses (not deployed on other networks).
- Mainnet Stable Pool handling is currently commented out so left it like that.