### PR TITLE
feat: add ConvergentCurvePool factory to schema

### DIFF
--- a/subgraph.polygon.yaml
+++ b/subgraph.polygon.yaml
@@ -67,32 +67,32 @@ dataSources:
         - event: PoolCreated(indexed address)
           handler: handleNewWeightedPool
   - kind: ethereum/contract
-      name: WeightedPool2TokenFactory
-      network: matic
-      source:
-        address: '0xA5bf2ddF098bb0Ef6d120C98217dD6B141c74EE0'
-        abi: WeightedPoolFactory
-        startBlock: 15869090
-      mapping:
-        kind: ethereum/events
-        apiVersion: 0.0.4
-        language: wasm/assemblyscript
-        file: ./src/mappings/poolFactory.ts
-        entities:
-          - Balancer
-          - Pool
-        abis:
-          - name: Vault
-            file: ./abis/Vault.json
-          - name: ERC20
-            file: ./abis/ERC20.json
-          - name: WeightedPoolFactory
-            file: ./abis/WeightedPoolFactory.json
-          - name: WeightedPool
-            file: ./abis/WeightedPool.json
-        eventHandlers:
-          - event: PoolCreated(indexed address)
-            handler: handleNewWeightedPool
+    name: WeightedPool2TokenFactory
+    network: matic
+    source:
+      address: '0xA5bf2ddF098bb0Ef6d120C98217dD6B141c74EE0'
+      abi: WeightedPoolFactory
+      startBlock: 15869090
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      file: ./src/mappings/poolFactory.ts
+      entities:
+        - Balancer
+        - Pool
+      abis:
+        - name: Vault
+          file: ./abis/Vault.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: WeightedPoolFactory
+          file: ./abis/WeightedPoolFactory.json
+        - name: WeightedPool
+          file: ./abis/WeightedPool.json
+      eventHandlers:
+        - event: PoolCreated(indexed address)
+          handler: handleNewWeightedPool
 templates:
   - kind: ethereum/contract
     name: WeightedPool

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -93,33 +93,33 @@ dataSources:
       eventHandlers:
         - event: PoolCreated(indexed address)
           handler: handleNewWeightedPool
-  # - kind: ethereum/contract
-  #   name: ConvergentPoolFactory
-  #   network: mainnet
-  #   source:
-  #     address: '0x0766B218517d9dC198155f0dC3485270cF788aF7'
-  #     abi: ConvergentPoolFactory
-  #     startBlock: 12272146
-  #   mapping:
-  #     kind: ethereum/events
-  #     apiVersion: 0.0.4
-  #     language: wasm/assemblyscript
-  #     file: ./src/mappings/poolFactory.ts
-  #     entities:
-  #       - Balancer
-  #       - Pool
-  #     abis:
-  #       - name: Vault
-  #         file: ./abis/Vault.json
-  #       - name: ERC20
-  #         file: ./abis/ERC20.json
-  #       - name: ConvergentPoolFactory
-  #         file: ./abis/ConvergentPoolFactory.json
-  #       - name: ConvergentCurvePool
-  #         file: ./abis/ConvergentCurvePool.json
-  #     eventHandlers:
-  #       - event: PoolCreated(indexed address)
-  #         handler: handleNewCCPPool
+  - kind: ethereum/contract
+    name: ConvergentPoolFactory
+    network: mainnet
+    source:
+      address: '0xb7561f547F3207eDb42A6AfA42170Cd47ADD17BD'
+      abi: ConvergentPoolFactory
+      startBlock: 12686198
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      file: ./src/mappings/poolFactory.ts
+      entities:
+        - Balancer
+        - Pool
+      abis:
+        - name: Vault
+          file: ./abis/Vault.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: ConvergentPoolFactory
+          file: ./abis/ConvergentPoolFactory.json
+        - name: ConvergentCurvePool
+          file: ./abis/ConvergentCurvePool.json
+      eventHandlers:
+        - event: PoolCreated(indexed address)
+          handler: handleNewCCPPool
   #- kind: ethereum/contract
     #name: StablePoolFactory
     #network: mainnet


### PR DESCRIPTION
Now that [element.fi](https://element.fi) has launched on mainnet it makes sense to add their factory to the mainnet subgraph.