### PR TITLE
Fix indentation in polygon schema

### DIFF
--- a/subgraph.polygon.yaml
+++ b/subgraph.polygon.yaml
@@ -67,32 +67,32 @@ dataSources:
         - event: PoolCreated(indexed address)
           handler: handleNewWeightedPool
   - kind: ethereum/contract
-      name: WeightedPool2TokenFactory
-      network: matic
-      source:
-        address: '0xA5bf2ddF098bb0Ef6d120C98217dD6B141c74EE0'
-        abi: WeightedPoolFactory
-        startBlock: 15869090
-      mapping:
-        kind: ethereum/events
-        apiVersion: 0.0.4
-        language: wasm/assemblyscript
-        file: ./src/mappings/poolFactory.ts
-        entities:
-          - Balancer
-          - Pool
-        abis:
-          - name: Vault
-            file: ./abis/Vault.json
-          - name: ERC20
-            file: ./abis/ERC20.json
-          - name: WeightedPoolFactory
-            file: ./abis/WeightedPoolFactory.json
-          - name: WeightedPool
-            file: ./abis/WeightedPool.json
-        eventHandlers:
-          - event: PoolCreated(indexed address)
-            handler: handleNewWeightedPool
+    name: WeightedPool2TokenFactory
+    network: matic
+    source:
+      address: '0xA5bf2ddF098bb0Ef6d120C98217dD6B141c74EE0'
+      abi: WeightedPoolFactory
+      startBlock: 15869090
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      file: ./src/mappings/poolFactory.ts
+      entities:
+        - Balancer
+        - Pool
+      abis:
+        - name: Vault
+          file: ./abis/Vault.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: WeightedPoolFactory
+          file: ./abis/WeightedPoolFactory.json
+        - name: WeightedPool
+          file: ./abis/WeightedPool.json
+      eventHandlers:
+        - event: PoolCreated(indexed address)
+          handler: handleNewWeightedPool
 templates:
   - kind: ethereum/contract
     name: WeightedPool


### PR DESCRIPTION
There was some bad indentation in the previous schema which prevented deployments.