### PR TITLE
Always save pool entity on creation

### DIFF
--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -62,8 +62,8 @@ export function handleNewWeightedPool(event: PoolCreated): void {
 
     pool.tokensList = tokensList;
     pool.totalWeight = totalWeight;
-    pool.save();
   }
+  pool.save();
 
   WeightedPoolTemplate.create(poolAddress);
 }
@@ -114,8 +114,8 @@ export function handleNewStablePool(event: PoolCreated): void {
     pool.amp = amp;
 
     pool.tokensList = tokensList;
-    pool.save();
   }
+  pool.save();
 
   StablePoolTemplate.create(poolAddress);
 }
@@ -176,8 +176,8 @@ export function handleNewCCPPool(event: PoolCreated): void {
     }
 
     pool.tokensList = tokensList;
-    pool.save();
   }
+  pool.save();
 
   CCPoolTemplate.create(poolAddress);
 }


### PR DESCRIPTION
This PR modifies the subgraph handlers to always save when a new pool is created from a pool factory - regardless of whether it is able to fetch pool data.

Specifically, the `PoolCreated` event handlers for various pool factories try and get pool data (tokens, weights, etc.) when a new pool is created. This is done by performing an `eth_call` to read on-chain. However, `eth_call`s are only supported on certain networks that run with archive nodes (i.e. Mainnet, but **not** test nets) which means that pool info is always missing for test networks.

This causes the `pool.save()` to never get called on these test networks, making pool information (like `factory`, `poolType` to never be set, even if this information is available.

With this change, `pool.save()` is called unconditionally so some of the aforementioned entity fields get saved even on networks without archive nodes, such as various test networks.

I'm not sure how to test these changes, or how these changes get released.