### PR TITLE
feat: add network addresses for rinkeby

### DIFF
--- a/src/mappings/constants.ts
+++ b/src/mappings/constants.ts
@@ -8,6 +8,7 @@ export class AddressByNetwork {
   public mainnet: string;
   public kovan: string;
   public goerli: string;
+  public rinkeby: string;
   public polygon: string;
   public dev: string;
 }
@@ -18,6 +19,7 @@ let vaultAddressByNetwork: AddressByNetwork = {
   mainnet: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
   kovan: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
   goerli: '0x65748E8287Ce4B9E6D83EE853431958851550311',
+  rinkeby: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
   polygon: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
   dev: '0xa0B05b20e511B1612E908dFCeE0E407E22B76028',
 };
@@ -26,6 +28,7 @@ let wethAddressByNetwork: AddressByNetwork = {
   mainnet: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
   kovan: '0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1',
   goerli: '0x9A1000D492d40bfccbc03f413A48F5B6516Ec0Fd',
+  rinkeby: '0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1',
   polygon: '0x7ceb23fd6bc0add59e62ac25578270cff1b9f619',
   dev: '0x4CDDb3505Cf09ee0Fa0877061eB654839959B9cd',
 };
@@ -34,6 +37,7 @@ let wbtcAddressByNetwork: AddressByNetwork = {
   mainnet: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
   kovan: '0x1C8E3Bcb3378a443CC591f154c5CE0EBb4dA9648',
   goerli: '0x78dEca24CBa286C0f8d56370f5406B48cFCE2f86',
+  rinkeby: '0xc3dbf84Abb494ce5199D5d4D815b10EC29529ff8',
   polygon: '0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6',
   dev: '0xcD80986f08d776CE41698c47f705CDc99dDBfB0A',
 };
@@ -42,6 +46,7 @@ let usdAddressByNetwork: AddressByNetwork = {
   mainnet: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
   kovan: '0xc2569dd7d0fd715B054fBf16E75B001E5c0C1115',
   goerli: '0x78dEca24CBa286C0f8d56370f5406B48cFCE2f86',
+  rinkeby: '0xc3dbf84Abb494ce5199D5d4D815b10EC29529ff8',
   polygon: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174',
   dev: '0x1528f3fcc26d13f7079325fb78d9442607781c8c',
 };
@@ -50,6 +55,7 @@ let usdcAddressByNetwork: AddressByNetwork = {
   mainnet: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
   kovan: '0xc2569dd7d0fd715B054fBf16E75B001E5c0C1115',
   goerli: '0x78dEca24CBa286C0f8d56370f5406B48cFCE2f86',
+  rinkeby: '0xc3dbf84Abb494ce5199D5d4D815b10EC29529ff8',
   polygon: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174',
   dev: '0x7c0c5AdA758cf764EcD6bAC05b63b2482f90bBB2',
 };
@@ -58,6 +64,7 @@ let balAddressByNetwork: AddressByNetwork = {
   mainnet: '0xba100000625a3754423978a60c9317c58a424e3D',
   kovan: '0x41286Bb1D3E870f3F750eB7E1C25d7E48c8A1Ac7',
   goerli: '0x78dEca24CBa286C0f8d56370f5406B48cFCE2f86',
+  rinkeby: '0xc3dbf84Abb494ce5199D5d4D815b10EC29529ff8',
   polygon: '0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3',
   dev: '0xf702269193081364E355f862f2CFbFCdC5DB738C',
 };
@@ -66,6 +73,7 @@ let daiAddressByNetwork: AddressByNetwork = {
   mainnet: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
   kovan: '0x04DF6e4121c27713ED22341E7c7Df330F56f289B',
   goerli: '0x78dEca24CBa286C0f8d56370f5406B48cFCE2f86',
+  rinkeby: '0xc3dbf84Abb494ce5199D5d4D815b10EC29529ff8',
   polygon: '0x8f3cf7ad23cd3cadbd9735aff958023239c6a063',
   dev: '0x5C0E66606eAbEC1df45E2ADd26C5DF8C0895a397',
 };
@@ -77,6 +85,8 @@ function forNetwork(addressByNetwork: AddressByNetwork, network: string): Addres
     return Address.fromString(addressByNetwork.kovan);
   } else if (network == 'goerli') {
     return Address.fromString(addressByNetwork.goerli);
+  } else if (network == 'rinkeby') {
+    return Address.fromString(addressByNetwork.rinkeby);
   } else if (network == 'matic') {
     return Address.fromString(addressByNetwork.polygon);
   } else {


### PR DESCRIPTION
Our Rinkeby subgraph is consistently failing due to not having the important addresses (including the vault), which this PR adds.