### PR TITLE
Track scheduled weight updates on LBPs 

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -48,6 +48,9 @@ type Pool @entity {
   shares: [PoolShare!] @derivedFrom(field: "poolId")
   historicalValues: [PoolHistoricalLiquidity!] @derivedFrom(field: "poolId")
 
+  # LiquidityBootstrappingPool Only
+  weightUpdates: [GradualWeightUpdate!] @derivedFrom(field: "poolId")
+
   # StablePool Only
   amp: BigInt
 
@@ -93,6 +96,16 @@ type UserInternalBalance @entity {
   userAddress: User
   token: Bytes!
   balance: BigDecimal!
+}
+
+type GradualWeightUpdate @entity {
+  id: ID!
+  poolId: Pool!
+  scheduledTimestamp: Int!
+  startTimestamp: Int!
+  endTimestamp: Int!
+  startWeights: [BigInt!]!
+  endWeights: [BigInt!]!
 }
 
 type Swap @entity {

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -1,10 +1,14 @@
 import { BigInt } from '@graphprotocol/graph-ts';
 import { Transfer } from '../types/templates/WeightedPool/BalancerPoolToken';
 import { WeightedPool, SwapFeePercentageChanged } from '../types/templates/WeightedPool/WeightedPool';
-import { SwapEnabledSet } from '../types/templates/LiquidityBootstrappingPool/LiquidityBootstrappingPool';
+import {
+  GradualWeightUpdateScheduled,
+  LiquidityBootstrappingPool,
+  SwapEnabledSet,
+} from '../types/templates/LiquidityBootstrappingPool/LiquidityBootstrappingPool';
 import { ConvergentCurvePool } from '../types/templates/ConvergentCurvePool/ConvergentCurvePool';
 
-import { PoolShare, Pool } from '../types/schema';
+import { PoolShare, Pool, GradualWeightUpdate } from '../types/schema';
 import { tokenToDecimal, createPoolShareEntity, getPoolShareId, scaleDown } from './helpers/misc';
 import { ZERO_ADDRESS, ZERO_BD } from './helpers/constants';
 
@@ -24,6 +28,29 @@ export function handleSwapEnabledSet(event: SwapEnabledSet): void {
 
   pool.swapEnabled = event.params.swapEnabled;
   pool.save();
+}
+
+/************************************
+ ********** WEIGHT UPDATES **********
+ ************************************/
+
+export function handleGradualWeightUpdateScheduled(event: GradualWeightUpdateScheduled): void {
+  let poolAddress = event.address;
+
+  // TODO - refactor so pool -> poolId doesn't require call
+  let poolContract = LiquidityBootstrappingPool.bind(poolAddress);
+  let poolIdCall = poolContract.try_getPoolId();
+  let poolId = poolIdCall.value;
+
+  let id = event.transaction.hash.toHexString().concat(event.transactionLogIndex.toString());
+  let weightUpdate = new GradualWeightUpdate(id);
+  weightUpdate.poolId = poolId.toHexString();
+  weightUpdate.scheduledTimestamp = event.block.timestamp.toI32();
+  weightUpdate.startTimestamp = event.params.startTime.toI32();
+  weightUpdate.endTimestamp = event.params.endTime.toI32();
+  weightUpdate.startWeights = event.params.startWeights;
+  weightUpdate.endWeights = event.params.endWeights;
+  weightUpdate.save();
 }
 
 /************************************

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -18,7 +18,7 @@ import { StablePool } from '../types/templates/StablePool/StablePool';
 import { ConvergentCurvePool } from '../types/templates/ConvergentCurvePool/ConvergentCurvePool';
 import { ERC20 } from '../types/Vault/ERC20';
 
-function createNewWeightedPool(event: PoolCreated): Pool {
+function createNewWeightedPool(event: PoolCreated): string {
   let poolAddress: Address = event.params.pool;
   let poolContract = WeightedPool.bind(poolAddress);
 
@@ -60,7 +60,7 @@ function createNewWeightedPool(event: PoolCreated): Pool {
   // Load pool with initial weights
   updatePoolWeights(poolId.toHexString());
 
-  return pool;
+  return poolId.toHexString();
 }
 
 export function handleNewWeightedPool(event: PoolCreated): void {
@@ -69,11 +69,13 @@ export function handleNewWeightedPool(event: PoolCreated): void {
 }
 
 export function handleNewLiquidityBootstrappingPool(event: PoolCreated): void {
-  let pool = createNewWeightedPool(event);
+  let poolId = createNewWeightedPool(event);
+
+  let pool = Pool.load(poolId);
   pool.poolType = PoolType.LiquidityBootstrapping;
   pool.save();
 
-  LiquidityBootstrappingPoolTemplate.create(event.params.pool);
+  LiquidityBootstrappingPoolTemplate.create(pool.address);
 }
 
 export function handleNewStablePool(event: PoolCreated): void {

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -75,7 +75,7 @@ export function handleNewLiquidityBootstrappingPool(event: PoolCreated): void {
   pool.poolType = PoolType.LiquidityBootstrapping;
   pool.save();
 
-  LiquidityBootstrappingPoolTemplate.create(pool.address);
+  LiquidityBootstrappingPoolTemplate.create(pool.address as Address);
 }
 
 export function handleNewStablePool(event: PoolCreated): void {

--- a/subgraph.kovan.yaml
+++ b/subgraph.kovan.yaml
@@ -212,6 +212,7 @@ templates:
       file: ./src/mappings/poolController.ts
       entities:
         - Pool
+        - GradualWeightUpdate
       abis:
         - name: WeightedPool
           file: ./abis/WeightedPool.json
@@ -224,3 +225,5 @@ templates:
           handler: handleSwapFeePercentageChange
         - event: SwapEnabledSet(bool)
           handler: handleSwapEnabledSet
+        - event: GradualWeightUpdateScheduled(uint256,uint256,uint256[],uint256[])
+          handler: handleGradualWeightUpdateScheduled

--- a/subgraph.polygon.yaml
+++ b/subgraph.polygon.yaml
@@ -212,6 +212,7 @@ templates:
       file: ./src/mappings/poolController.ts
       entities:
         - Pool
+        - GradualWeightUpdate
       abis:
         - name: WeightedPool
           file: ./abis/WeightedPool.json
@@ -224,3 +225,5 @@ templates:
           handler: handleSwapFeePercentageChange
         - event: SwapEnabledSet(bool)
           handler: handleSwapEnabledSet
+        - event: GradualWeightUpdateScheduled(uint256,uint256,uint256[],uint256[])
+          handler: handleGradualWeightUpdateScheduled

--- a/subgraph.rinkeby.yaml
+++ b/subgraph.rinkeby.yaml
@@ -158,6 +158,7 @@ templates:
       file: ./src/mappings/poolController.ts
       entities:
         - Pool
+        - GradualWeightUpdate
       abis:
         - name: WeightedPool
           file: ./abis/WeightedPool.json
@@ -170,3 +171,5 @@ templates:
           handler: handleSwapFeePercentageChange
         - event: SwapEnabledSet(bool)
           handler: handleSwapEnabledSet
+        - event: GradualWeightUpdateScheduled(uint256,uint256,uint256[],uint256[])
+          handler: handleGradualWeightUpdateScheduled

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -262,6 +262,7 @@ templates:
       file: ./src/mappings/poolController.ts
       entities:
         - Pool
+        - GradualWeightUpdate
       abis:
         - name: WeightedPool
           file: ./abis/WeightedPool.json
@@ -274,3 +275,5 @@ templates:
           handler: handleSwapFeePercentageChange
         - event: SwapEnabledSet(bool)
           handler: handleSwapEnabledSet
+        - event: GradualWeightUpdateScheduled(uint256,uint256,uint256[],uint256[])
+          handler: handleGradualWeightUpdateScheduled


### PR DESCRIPTION
This PR allows the frontend to reconstruct the pool's weights during an update without having to rely on swaps updating the subgraph directly.

Each `GradualWeightUpdateScheduled` event is tracked as a `GradualWeightUpdate`. By querying the most recently scheduled `GradualWeightUpdate` for a pool we can calculate what the pool's weights will be at any given timestamp.

We could embed these fields directly into the `Pool` entity but this method allows us to easily query historical pool weights which could be useful for graphing, etc. (although I'm open to arguments on this).