### PR TITLE
Push Arbitrum pricing assets fix to production.

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -64,15 +64,13 @@ type PoolToken @entity {
   name: String
   decimals: Int!
   address: String!
+  priceRate: BigDecimal!
   balance: BigDecimal!
   invested: BigDecimal!
   investments: [Investment!] @derivedFrom(field: "poolTokenId")
 
   # WeightedPool Only
   weight: BigDecimal
-
-  # MetaStablePool Only
-  priceRate: BigDecimal
 }
 
 type PriceRateProvider @entity {

--- a/src/mappings/helpers/constants.ts
+++ b/src/mappings/helpers/constants.ts
@@ -21,6 +21,7 @@ export class AddressByNetwork {
   public goerli: string;
   public rinkeby: string;
   public polygon: string;
+  public arbitrum: string;
   public dev: string;
 }
 
@@ -32,6 +33,7 @@ let vaultAddressByNetwork: AddressByNetwork = {
   goerli: '0x65748E8287Ce4B9E6D83EE853431958851550311',
   rinkeby: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
   polygon: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
+  arbitrum: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
   dev: '0xa0B05b20e511B1612E908dFCeE0E407E22B76028',
 };
 
@@ -41,6 +43,7 @@ let wethAddressByNetwork: AddressByNetwork = {
   goerli: '0x9A1000D492d40bfccbc03f413A48F5B6516Ec0Fd',
   rinkeby: '0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1',
   polygon: '0x7ceb23fd6bc0add59e62ac25578270cff1b9f619',
+  arbitrum: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
   dev: '0x4CDDb3505Cf09ee0Fa0877061eB654839959B9cd',
 };
 
@@ -50,6 +53,7 @@ let wbtcAddressByNetwork: AddressByNetwork = {
   goerli: '0x78dEca24CBa286C0f8d56370f5406B48cFCE2f86',
   rinkeby: '0xc3dbf84Abb494ce5199D5d4D815b10EC29529ff8',
   polygon: '0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6',
+  arbitrum: '0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f',
   dev: '0xcD80986f08d776CE41698c47f705CDc99dDBfB0A',
 };
 
@@ -59,6 +63,7 @@ let usdAddressByNetwork: AddressByNetwork = {
   goerli: '0x78dEca24CBa286C0f8d56370f5406B48cFCE2f86',
   rinkeby: '0xc3dbf84Abb494ce5199D5d4D815b10EC29529ff8',
   polygon: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174',
+  arbitrum: '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8',
   dev: '0x1528f3fcc26d13f7079325fb78d9442607781c8c',
 };
 
@@ -68,6 +73,7 @@ let usdcAddressByNetwork: AddressByNetwork = {
   goerli: '0x78dEca24CBa286C0f8d56370f5406B48cFCE2f86',
   rinkeby: '0xc3dbf84Abb494ce5199D5d4D815b10EC29529ff8',
   polygon: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174',
+  arbitrum: '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8',
   dev: '0x7c0c5AdA758cf764EcD6bAC05b63b2482f90bBB2',
 };
 
@@ -77,6 +83,7 @@ let balAddressByNetwork: AddressByNetwork = {
   goerli: '0x78dEca24CBa286C0f8d56370f5406B48cFCE2f86',
   rinkeby: '0xc3dbf84Abb494ce5199D5d4D815b10EC29529ff8',
   polygon: '0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3',
+  arbitrum: '0x040d1EdC9569d4Bab2D15287Dc5A4F10F56a56B8',
   dev: '0xf702269193081364E355f862f2CFbFCdC5DB738C',
 };
 
@@ -86,6 +93,7 @@ let daiAddressByNetwork: AddressByNetwork = {
   goerli: '0x78dEca24CBa286C0f8d56370f5406B48cFCE2f86',
   rinkeby: '0xc3dbf84Abb494ce5199D5d4D815b10EC29529ff8',
   polygon: '0x8f3cf7ad23cd3cadbd9735aff958023239c6a063',
+  arbitrum: '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8', // DAI not deployed yet so lets just use USDC
   dev: '0x5C0E66606eAbEC1df45E2ADd26C5DF8C0895a397',
 };
 
@@ -100,6 +108,8 @@ function forNetwork(addressByNetwork: AddressByNetwork, network: string): Addres
     return Address.fromString(addressByNetwork.rinkeby);
   } else if (network == 'matic') {
     return Address.fromString(addressByNetwork.polygon);
+  } else if (network == 'arbitrum-one') {
+    return Address.fromString(addressByNetwork.arbitrum);
   } else {
     return Address.fromString(addressByNetwork.dev);
   }

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -1,7 +1,7 @@
 import { BigDecimal, Address, BigInt } from '@graphprotocol/graph-ts';
 import { Pool, User, PoolToken, PoolShare, PoolSnapshot, PriceRateProvider } from '../../types/schema';
 import { ERC20 } from '../../types/Vault/ERC20';
-import { ZERO_BD } from './constants';
+import { ONE_BD, ZERO_BD } from './constants';
 
 const DAY = 24 * 60 * 60;
 
@@ -107,6 +107,7 @@ export function createPoolTokenEntity(poolId: string, tokenAddress: Address): vo
   poolToken.decimals = decimals;
   poolToken.balance = ZERO_BD;
   poolToken.invested = ZERO_BD;
+  poolToken.priceRate = ONE_BD;
   poolToken.save();
 }
 

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -1,5 +1,5 @@
-import { ONE_BD, ZERO_BD, VAULT_ADDRESS, PoolType } from './helpers/constants';
-import { newPoolEntity, createPoolTokenEntity, scaleDown, loadPoolToken } from './helpers/misc';
+import { ZERO_BD, VAULT_ADDRESS, PoolType } from './helpers/constants';
+import { newPoolEntity, createPoolTokenEntity, scaleDown } from './helpers/misc';
 import { updatePoolWeights } from './helpers/weighted';
 
 import { BigInt, Address, Bytes } from '@graphprotocol/graph-ts';
@@ -146,10 +146,6 @@ export function handleNewMetaStablePool(event: PoolCreated): void {
 
     for (let i: i32 = 0; i < tokens.length; i++) {
       createPoolTokenEntity(poolId.toHexString(), tokens[i]);
-
-      let poolToken = loadPoolToken(poolId.toHexString(), tokens[i]);
-      poolToken.priceRate = ONE_BD;
-      poolToken.save();
     }
   }
 

--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -1,4 +1,4 @@
-import { PRICING_ASSETS, USD_STABLE_ASSETS, USDC, DAI } from './helpers/constants';
+import { PRICING_ASSETS, USD_STABLE_ASSETS } from './helpers/constants';
 import { getTokenPriceId, loadPoolToken } from './helpers/misc';
 import { Address, Bytes, BigInt, BigDecimal } from '@graphprotocol/graph-ts';
 import { Pool, TokenPrice, Balancer, PoolHistoricalLiquidity, LatestPrice } from '../types/schema';
@@ -104,16 +104,12 @@ export function valueInUSD(value: BigDecimal, pricingAsset: Address): BigDecimal
     usdValue = value;
   } else {
     // convert to USD
-    let pricingAssetInUSDId: string = getLatestPriceId(pricingAsset, USDC);
-    let pricingAssetInUSD = LatestPrice.load(pricingAssetInUSDId);
-
-    if (!pricingAssetInUSD) {
-      pricingAssetInUSDId = getLatestPriceId(pricingAsset, DAI);
-      pricingAssetInUSD = LatestPrice.load(pricingAssetInUSDId);
-    }
-
-    if (pricingAssetInUSD) {
-      usdValue = value.times(pricingAssetInUSD.price);
+    for (let i: i32 = 0; i < USD_STABLE_ASSETS.length; i++) {
+      let pricingAssetInUSD = LatestPrice.load(getLatestPriceId(pricingAsset, USD_STABLE_ASSETS[i]));
+      if (pricingAssetInUSD != null) {
+        usdValue = value.times(pricingAssetInUSD.price);
+        break;
+      }
     }
   }
 
@@ -129,7 +125,6 @@ function getPoolHistoricalLiquidityId(poolId: string, tokenAddress: Address, blo
 }
 
 function isUSDStable(asset: Address): boolean {
-  //for (let pa of PRICING_ASSETS) {
   for (let i: i32 = 0; i < USD_STABLE_ASSETS.length; i++) {
     if (USD_STABLE_ASSETS[i] == asset) return true;
   }

--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -11,19 +11,12 @@ export function isPricingAsset(asset: Address): boolean {
   return false;
 }
 
-export function updatePoolLiquidity(poolId: string, block: BigInt, pricingAsset: Address): void {
+export function updatePoolLiquidity(poolId: string, block: BigInt, pricingAsset: Address): boolean {
   let pool = Pool.load(poolId);
-  if (pool == null) return;
+  if (pool == null) return false;
 
   let tokensList: Bytes[] = pool.tokensList;
-  if (tokensList.length < 2) return;
-
-  let phlId = getPoolHistoricalLiquidityId(poolId, pricingAsset, block);
-  let phl = new PoolHistoricalLiquidity(phlId);
-  phl.poolId = poolId;
-  phl.pricingAsset = pricingAsset;
-  phl.block = block;
-  phl.poolTotalShares = pool.totalShares;
+  if (tokensList.length < 2) return false;
 
   let poolValue: BigDecimal = BigDecimal.fromString('0');
 
@@ -70,21 +63,38 @@ export function updatePoolLiquidity(poolId: string, block: BigInt, pricingAsset:
       poolValue = poolValue.plus(poolTokenValue);
     }
   }
-  phl.poolLiquidity = poolValue;
-  phl.poolShareValue = poolValue.div(pool.totalShares);
-  phl.save();
 
   let oldPoolLiquidity: BigDecimal = pool.totalLiquidity;
   let newPoolLiquidity: BigDecimal = valueInUSD(poolValue, pricingAsset) || ZERO_BD;
 
-  if (newPoolLiquidity && oldPoolLiquidity) {
-    let vault = Balancer.load('2');
-    let liquidityChange: BigDecimal = newPoolLiquidity.minus(oldPoolLiquidity);
-    vault.totalLiquidity = vault.totalLiquidity.plus(liquidityChange);
-    vault.save();
-    pool.totalLiquidity = newPoolLiquidity;
-    pool.save();
+  // If the pool isn't empty but we have a zero USD value then it's likely that we have a bad pricing asset
+  // Don't commit any changes and just report the failure.
+  if (poolValue.gt(ZERO_BD) != newPoolLiquidity.gt(ZERO_BD)) {
+    return false;
   }
+
+  // Take snapshot of pool state
+  let phlId = getPoolHistoricalLiquidityId(poolId, pricingAsset, block);
+  let phl = new PoolHistoricalLiquidity(phlId);
+  phl.poolId = poolId;
+  phl.pricingAsset = pricingAsset;
+  phl.block = block;
+  phl.poolTotalShares = pool.totalShares;
+  phl.poolLiquidity = poolValue;
+  phl.poolShareValue = poolValue.div(pool.totalShares);
+  phl.save();
+
+  // Update pool stats
+  pool.totalLiquidity = newPoolLiquidity;
+  pool.save();
+
+  // Update global stats
+  let vault = Balancer.load('2');
+  let liquidityChange: BigDecimal = newPoolLiquidity.minus(oldPoolLiquidity);
+  vault.totalLiquidity = vault.totalLiquidity.plus(liquidityChange);
+  vault.save();
+
+  return true;
 }
 
 export function valueInUSD(value: BigDecimal, pricingAsset: Address): BigDecimal {

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -112,8 +112,12 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
   for (let i: i32 = 0; i < tokenAddresses.length; i++) {
     let tokenAddress: Address = Address.fromString(tokenAddresses[i].toHexString());
     if (isPricingAsset(tokenAddress)) {
-      updatePoolLiquidity(poolId, event.block.number, tokenAddress);
-      break;
+      let success = updatePoolLiquidity(poolId, event.block.number, tokenAddress);
+      // Some pricing assets may not have a route back to USD yet
+      // so we keep trying until we find one
+      if (success) {
+        break;
+      }
     }
   }
 
@@ -171,8 +175,12 @@ function handlePoolExited(event: PoolBalanceChanged): void {
   for (let i: i32 = 0; i < tokenAddresses.length; i++) {
     let tokenAddress: Address = Address.fromString(tokenAddresses[i].toHexString());
     if (isPricingAsset(tokenAddress)) {
-      updatePoolLiquidity(poolId, event.block.number, tokenAddress);
-      break;
+      let success = updatePoolLiquidity(poolId, event.block.number, tokenAddress);
+      // Some pricing assets may not have a route back to USD yet
+      // so we keep trying until we find one
+      if (success) {
+        break;
+      }
     }
   }
 

--- a/subgraph.arbitrum.yaml
+++ b/subgraph.arbitrum.yaml
@@ -143,6 +143,8 @@ dataSources:
           file: ./abis/MetaStablePoolFactory.json
         - name: StablePool
           file: ./abis/StablePool.json
+        - name: MetaStablePool
+          file: ./abis/MetaStablePool.json
       eventHandlers:
         - event: PoolCreated(indexed address)
           handler: handleNewMetaStablePool

--- a/subgraph.kovan.yaml
+++ b/subgraph.kovan.yaml
@@ -143,6 +143,8 @@ dataSources:
           file: ./abis/MetaStablePoolFactory.json
         - name: StablePool
           file: ./abis/StablePool.json
+        - name: MetaStablePool
+          file: ./abis/MetaStablePool.json
       eventHandlers:
         - event: PoolCreated(indexed address)
           handler: handleNewMetaStablePool

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -146,6 +146,8 @@ dataSources:
           file: ./abis/MetaStablePoolFactory.json
         - name: StablePool
           file: ./abis/StablePool.json
+        - name: MetaStablePool
+          file: ./abis/MetaStablePool.json
       eventHandlers:
         - event: PoolCreated(indexed address)
           handler: handleNewMetaStablePool

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -143,6 +143,8 @@ dataSources:
           file: ./abis/MetaStablePoolFactory.json
         - name: StablePool
           file: ./abis/StablePool.json
+        - name: MetaStablePool
+          file: ./abis/MetaStablePool.json
       eventHandlers:
         - event: PoolCreated(indexed address)
           handler: handleNewMetaStablePool


### PR DESCRIPTION
This PR prevents BAL's lack of direct connection to USDC combined with its low address on Arbitrum resulting in BAL pools occasionally  having a total liquidity of zero.

Also includes the change that token `priceRates` are set to 1 as default rather than left as null.