### PR TITLE
Add Token (and historical) and TradePair (and historical) entities

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -219,9 +219,9 @@ type TokenSnapshot @entity {
   timestamp: Int! # timestamp representing the start of day in UTC
   volumeUSD: BigDecimal! # amount of volume the token has moved on this day
   volumeNotional: BigDecimal! # underyling asset volume
-  balanceUSD: BigDecimal! # total balance of tokens across balancer
-  balanceNotional: BigDecimal! # underlying asset balance
-  swapCount: BigInt!
+  totalBalanceUSD: BigDecimal! # total balance of tokens across balancer
+  totalBalanceNotional: BigDecimal! # underlying asset balance
+  totalSwapCount: BigInt!
 }
 
 type TradePair @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -226,3 +226,20 @@ type TokenSnapshot @entity {
   totalBalanceNotional: BigDecimal! # underlying asset balance
   totalSwapCount: BigInt!
 }
+
+type TradePair @entity {
+  "Token Address - Token Address"
+  id: ID!
+  token0: Token!
+  token1: Token!
+  totalSwapVolume: BigDecimal!
+  totalSwapFee: BigDecimal!
+}
+
+type TradePairSnapshot @entity {
+  id: ID!
+  pair: TradePair!
+  timestamp: Int!
+  swapVolume: BigDecimal!
+  swapFee: BigDecimal!
+} 

--- a/schema.graphql
+++ b/schema.graphql
@@ -74,6 +74,7 @@ type PoolToken @entity {
 
   # WeightedPool Only
   weight: BigDecimal
+  token: Token!
 }
 
 type PriceRateProvider @entity {
@@ -196,4 +197,32 @@ type PoolSnapshot @entity {
   swapVolume: BigDecimal!
   swapFees: BigDecimal!
   timestamp: Int!
+}
+
+type Token @entity {
+  id: ID!
+  poolId: Pool!
+  symbol: String
+  name: String
+  decimals: Int!
+  address: String!
+  priceRate: BigDecimal!
+  totalBalanceUSD: BigDecimal! # total balance of tokens across balancer
+  totalBalanceNotional: BigDecimal!
+  totalVolumeUSD: BigDecimal! # total volume in fiat (usd)
+  totalVolumeNotional: BigDecimal!
+  totalSwapCount: BigInt!
+  poolCount: BigInt! # number of pools with this token
+  latestPrice: LatestPrice # latest price of token, updated when pool liquidity changes
+}
+
+type TokenSnapshot @entity {
+  id: ID! # token address + dayId
+  token: Token!
+  timestamp: Int! # timestamp representing the start of day in UTC
+  totalVolumeUSD: BigDecimal! # amount of volume the token has moved on this day
+  totalVolumeNotional: BigDecimal! # underyling asset volume
+  totalBalanceUSD: BigDecimal! # total balance of tokens across balancer
+  totalBalanceNotional: BigDecimal! # underlying asset balance
+  totalSwapCount: BigInt!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -201,18 +201,15 @@ type PoolSnapshot @entity {
 
 type Token @entity {
   id: ID!
-  poolId: Pool!
   symbol: String
   name: String
   decimals: Int!
   address: String!
-  priceRate: BigDecimal!
   totalBalanceUSD: BigDecimal! # total balance of tokens across balancer
   totalBalanceNotional: BigDecimal!
   totalVolumeUSD: BigDecimal! # total volume in fiat (usd)
   totalVolumeNotional: BigDecimal!
   totalSwapCount: BigInt!
-  poolCount: BigInt! # number of pools with this token
   latestPrice: LatestPrice # latest price of token, updated when pool liquidity changes
 }
 
@@ -220,11 +217,11 @@ type TokenSnapshot @entity {
   id: ID! # token address + dayId
   token: Token!
   timestamp: Int! # timestamp representing the start of day in UTC
-  totalVolumeUSD: BigDecimal! # amount of volume the token has moved on this day
-  totalVolumeNotional: BigDecimal! # underyling asset volume
-  totalBalanceUSD: BigDecimal! # total balance of tokens across balancer
-  totalBalanceNotional: BigDecimal! # underlying asset balance
-  totalSwapCount: BigInt!
+  volumeUSD: BigDecimal! # amount of volume the token has moved on this day
+  volumeNotional: BigDecimal! # underyling asset volume
+  balanceUSD: BigDecimal! # total balance of tokens across balancer
+  balanceNotional: BigDecimal! # underlying asset balance
+  swapCount: BigInt!
 }
 
 type TradePair @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -217,8 +217,8 @@ type TokenSnapshot @entity {
   id: ID! # token address + dayId
   token: Token!
   timestamp: Int! # timestamp representing the start of day in UTC
-  volumeUSD: BigDecimal! # amount of volume the token has moved on this day
-  volumeNotional: BigDecimal! # underyling asset volume
+  totalVolumeUSD: BigDecimal! # amount of volume the token has moved on this day
+  totalVolumeNotional: BigDecimal! # underyling asset volume
   totalBalanceUSD: BigDecimal! # total balance of tokens across balancer
   totalBalanceNotional: BigDecimal! # underlying asset balance
   totalSwapCount: BigInt!

--- a/schema.graphql
+++ b/schema.graphql
@@ -237,6 +237,6 @@ type TradePairSnapshot @entity {
   id: ID!
   pair: TradePair!
   timestamp: Int!
-  swapVolume: BigDecimal!
-  swapFee: BigDecimal!
+  totalSwapVolume: BigDecimal!
+  totalSwapFee: BigDecimal!
 } 

--- a/schema.graphql
+++ b/schema.graphql
@@ -217,10 +217,10 @@ type TokenSnapshot @entity {
   id: ID! # token address + dayId
   token: Token!
   timestamp: Int! # timestamp representing the start of day in UTC
-  totalVolumeUSD: BigDecimal! # amount of volume the token has moved on this day
-  totalVolumeNotional: BigDecimal! # underyling asset volume
   totalBalanceUSD: BigDecimal! # total balance of tokens across balancer
   totalBalanceNotional: BigDecimal! # underlying asset balance
+  totalVolumeUSD: BigDecimal! # amount of volume the token has moved on this day
+  totalVolumeNotional: BigDecimal! # underyling asset volume
   totalSwapCount: BigInt!
 }
 
@@ -239,4 +239,4 @@ type TradePairSnapshot @entity {
   timestamp: Int!
   totalSwapVolume: BigDecimal!
   totalSwapFee: BigDecimal!
-} 
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -63,6 +63,7 @@ type Pool @entity {
 type PoolToken @entity {
   id: ID!
   poolId: Pool!
+  token: Token!
   symbol: String!
   name: String!
   decimals: Int!
@@ -74,7 +75,6 @@ type PoolToken @entity {
 
   # WeightedPool Only
   weight: BigDecimal
-  token: Token!
 }
 
 type PriceRateProvider @entity {

--- a/src/mappings/helpers/constants.ts
+++ b/src/mappings/helpers/constants.ts
@@ -3,6 +3,8 @@ import { BigDecimal, BigInt, Address, dataSource } from '@graphprotocol/graph-ts
 export let ZERO = BigInt.fromI32(0);
 export let ZERO_BD = BigDecimal.fromString('0');
 export let ONE_BD = BigDecimal.fromString('1');
+export const SWAP_IN = 0;
+export const SWAP_OUT = 1;
 
 export let ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -46,7 +46,7 @@ export function getPoolShare(poolId: string, lpAddress: Address): PoolShare {
   if (poolShare == null) {
     return createPoolShareEntity(poolId, lpAddress);
   }
-  return poolShare;
+  return poolShare as PoolShare;
 }
 
 export function createPoolShareEntity(poolId: string, lpAddress: Address): PoolShare {

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -263,9 +263,9 @@ export function getTokenSnapshot(tokenAddress: Address, event: ethereum.Event): 
     let token = getToken(tokenAddress);
     dayData = new TokenSnapshot(id);
     dayData.timestamp = dayStartTimestamp;
-    dayData.swapCount = ZERO;
-    dayData.balanceUSD = ZERO_BD;
-    dayData.balanceNotional = ZERO_BD;
+    dayData.totalSwapCount = token.totalSwapCount;
+    dayData.totalBalanceUSD = token.totalBalanceUSD;
+    dayData.totalBalanceNotional = token.totalBalanceNotional;
     dayData.volumeUSD = ZERO_BD;
     dayData.volumeNotional = ZERO_BD;
     dayData.token = token.id;
@@ -283,7 +283,7 @@ export function uptickSwapsForToken(tokenAddress: Address, event: ethereum.Event
 
   // update the snapshots
   let snapshot = getTokenSnapshot(tokenAddress, event);
-  snapshot.swapCount = token.totalSwapCount.plus(BigInt.fromI32(1));
+  snapshot.totalSwapCount = token.totalSwapCount;
   snapshot.save();
 }
 
@@ -299,16 +299,16 @@ export function updateTokenBalances(
 
   if (swapDirection == SWAP_IN) {
     token.totalBalanceNotional = token.totalBalanceNotional.plus(notionalBalance);
-    tokenSnapshot.balanceNotional = tokenSnapshot.balanceNotional.plus(notionalBalance);
+    tokenSnapshot.totalBalanceNotional = token.totalBalanceNotional;
 
     token.totalBalanceUSD = token.totalBalanceUSD.plus(usdBalance);
-    tokenSnapshot.balanceUSD = tokenSnapshot.balanceUSD.plus(usdBalance);
+    tokenSnapshot.totalBalanceUSD = token.totalBalanceUSD;
   } else if (swapDirection == SWAP_OUT) {
     token.totalBalanceNotional = token.totalBalanceNotional.minus(notionalBalance);
-    tokenSnapshot.balanceNotional = tokenSnapshot.balanceNotional.minus(notionalBalance);
+    tokenSnapshot.totalBalanceNotional = token.totalBalanceNotional;
 
     token.totalBalanceUSD = token.totalBalanceUSD.minus(usdBalance);
-    tokenSnapshot.balanceUSD = tokenSnapshot.balanceUSD.minus(usdBalance);
+    tokenSnapshot.totalBalanceUSD = tokenSnapshot.totalBalanceUSD.minus(usdBalance);
   }
 
   token.totalVolumeUSD = token.totalVolumeUSD.plus(usdBalance);

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -1,8 +1,9 @@
-import { BigDecimal, Address, BigInt } from '@graphprotocol/graph-ts';
-import { Pool, User, PoolToken, PoolShare, PoolSnapshot, PriceRateProvider } from '../../types/schema';
+import { BigDecimal, Address, BigInt, ethereum } from '@graphprotocol/graph-ts';
+import { Pool, User, PoolToken, PoolShare, PoolSnapshot, PriceRateProvider, Token, TokenSnapshot } from '../../types/schema';
 import { ERC20 } from '../../types/Vault/ERC20';
-import { ONE_BD, ZERO_BD } from './constants';
+import { ONE_BD, SWAP_IN, SWAP_OUT, ZERO, ZERO_BD } from './constants';
 import { getPoolAddress } from './pools';
+import { Swap as SwapEvent } from '../../types/Vault/Vault';
 
 const DAY = 24 * 60 * 60;
 
@@ -196,4 +197,113 @@ export function createUserEntity(address: Address): void {
     let user = new User(addressHex);
     user.save();
   }
+}
+
+export function createToken(tokenAddress: Address): Token {
+  let erc20token = ERC20.bind(tokenAddress);
+  let token = new Token(tokenAddress.toHexString());
+  let name = '';
+  let symbol = '';
+  let decimals = 0;
+
+  // attempt to retrieve erc20 values
+  let maybeName = erc20token.try_name();
+  let maybeSymbol = erc20token.try_symbol();
+  let maybeDecimals = erc20token.try_decimals();
+
+  if (!maybeName.reverted) name = maybeName.value;
+  if (!maybeSymbol.reverted) symbol = maybeSymbol.value;
+  if (!maybeDecimals.reverted) decimals = maybeDecimals.value;
+
+  token.name = name;
+  token.symbol = symbol;
+  token.decimals = decimals;
+  token.totalBalanceUSD = ZERO_BD;
+  token.totalBalanceNotional = ZERO_BD;
+  token.totalSwapCount = ZERO;
+  token.totalVolumeUSD = ZERO_BD;
+  token.totalVolumeNotional = ZERO_BD;
+  token.poolCount = ZERO;
+  token.address = tokenAddress.toHexString();
+  token.save();
+  return token;
+}
+
+// this will create the token entity and populate
+// with erc20 values
+export function getToken(tokenAddress: Address): Token {
+  let token = Token.load(tokenAddress.toHexString());
+  if (token == null) {
+    token = createToken(tokenAddress);
+  }
+  return token as Token;
+}
+
+export function getTokenSnapshot(tokenAddress: Address, event: ethereum.Event): TokenSnapshot {
+  let timestamp = event.block.timestamp.toI32();
+  let dayID = timestamp / 86400;
+  let id = tokenAddress.toHexString() + '-' + dayID.toString();
+  let dayData = TokenSnapshot.load(id);
+
+  if (dayData == null) {
+    let dayStartTimestamp = dayID * 86400;
+    let token = getToken(tokenAddress);
+    dayData = new TokenSnapshot(id);
+    dayData.timestamp = dayStartTimestamp;
+    dayData.totalSwapCount = ZERO;
+    dayData.totalBalanceUSD = ZERO_BD;
+    dayData.totalBalanceNotional = ZERO_BD;
+    dayData.totalVolumeUSD = ZERO_BD;
+    dayData.totalVolumeNotional = ZERO_BD;
+    dayData.token = token.id;
+    dayData.save();
+  }
+
+  return dayData as TokenSnapshot;
+}
+
+export function uptickSwapsForToken(tokenAddress: Address, event: ethereum.Event): void {
+  let token = getToken(tokenAddress);
+  // update the overall swap count for the token
+  token.totalSwapCount = token.totalSwapCount.plus(BigInt.fromI32(1));
+  token.save();
+
+  // update the snapshots
+  let snapshot = getTokenSnapshot(tokenAddress, event);
+  snapshot.totalSwapCount = token.totalSwapCount.plus(BigInt.fromI32(1));
+  snapshot.save();
+}
+
+export function updateTokenBalances(
+  tokenAddress: Address,
+  usdBalance: BigDecimal,
+  notionalBalance: BigDecimal,
+  swapDirection: i32,
+  event: SwapEvent
+): void {
+  let token = getToken(tokenAddress);
+  let tokenSnapshot = getTokenSnapshot(tokenAddress, event);
+
+  if (swapDirection == SWAP_IN) {
+    token.totalBalanceNotional = token.totalBalanceNotional.plus(notionalBalance);
+    tokenSnapshot.totalBalanceNotional = tokenSnapshot.totalBalanceNotional.plus(notionalBalance);
+
+    token.totalBalanceUSD = token.totalBalanceUSD.plus(usdBalance);
+    tokenSnapshot.totalBalanceUSD = tokenSnapshot.totalBalanceUSD.plus(usdBalance);
+  } else if (swapDirection == SWAP_OUT) {
+    token.totalBalanceNotional = token.totalBalanceNotional.minus(notionalBalance);
+    tokenSnapshot.totalBalanceNotional = tokenSnapshot.totalBalanceNotional.minus(notionalBalance);
+
+    token.totalBalanceUSD = token.totalBalanceUSD.minus(usdBalance);
+    tokenSnapshot.totalBalanceUSD = tokenSnapshot.totalBalanceUSD.minus(usdBalance);
+  }
+
+  token.totalVolumeUSD = token.totalVolumeUSD.plus(usdBalance);
+  tokenSnapshot.totalVolumeUSD = token.totalVolumeUSD.plus(usdBalance);
+
+  token.totalVolumeNotional = token.totalVolumeNotional.plus(notionalBalance);
+  tokenSnapshot.totalVolumeNotional = token.totalVolumeNotional.plus(notionalBalance);
+
+  token.save();
+  tokenSnapshot.save();
 }

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -266,8 +266,8 @@ export function getTokenSnapshot(tokenAddress: Address, event: ethereum.Event): 
     dayData.totalSwapCount = token.totalSwapCount;
     dayData.totalBalanceUSD = token.totalBalanceUSD;
     dayData.totalBalanceNotional = token.totalBalanceNotional;
-    dayData.totalVolumeUSD = ZERO_BD;
-    dayData.totalVolumeNotional = ZERO_BD;
+    dayData.totalVolumeUSD = token.totalVolumeUSD;
+    dayData.totalVolumeNotional = token.totalVolumeNotional;
     dayData.token = token.id;
     dayData.save();
   }
@@ -338,13 +338,14 @@ export function getTradePairSnapshot(tradePairId: string, timestamp: i32): Trade
   let dayID = timestamp / 86400;
   let id = tradePairId + '-' + dayID.toString();
   let snapshot = TradePairSnapshot.load(id);
-  if (!snapshot) {
+  let tradePair = TradePair.load(tradePairId);
+  if (!snapshot && tradePair != null) {
     snapshot = new TradePairSnapshot(id);
     let dayStartTimestamp = dayID * 86400;
     snapshot.pair = tradePairId;
     snapshot.timestamp = dayStartTimestamp;
-    snapshot.swapVolume = ZERO_BD;
-    snapshot.swapFee = ZERO_BD;
+    snapshot.totalSwapVolume = tradePair.totalSwapVolume;
+    snapshot.totalSwapFee = tradePair.totalSwapFee;
     snapshot.save();
   }
   return snapshot as TradePairSnapshot;

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -316,17 +316,17 @@ export function updateTokenBalances(
 }
 
 export function getTradePair(token0Address: Address, token1Address: Address): TradePair {
-  let sortedAddressses = new Array<string>(2);
-  sortedAddressses[0] = token0Address.toHexString();
-  sortedAddressses[1] = token1Address.toHexString();
-  sortedAddressses.sort();
+  let sortedAddresses = new Array<string>(2);
+  sortedAddresses[0] = token0Address.toHexString();
+  sortedAddresses[1] = token1Address.toHexString();
+  sortedAddresses.sort();
 
-  let tradePairId = sortedAddressses[0] + '-' + sortedAddressses[1];
+  let tradePairId = sortedAddresses[0] + '-' + sortedAddresses[1];
   let tradePair = TradePair.load(tradePairId);
   if (tradePair == null) {
     tradePair = new TradePair(tradePairId);
-    tradePair.token0 = sortedAddressses[0];
-    tradePair.token1 = sortedAddressses[1];
+    tradePair.token0 = sortedAddresses[0];
+    tradePair.token1 = sortedAddresses[1];
     tradePair.totalSwapFee = ZERO_BD;
     tradePair.totalSwapVolume = ZERO_BD;
     tradePair.save();

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -310,8 +310,8 @@ export function updateTokenBalances(
   let tokenSnapshot = getTokenSnapshot(tokenAddress, event);
   tokenSnapshot.totalBalanceNotional = token.totalBalanceNotional;
   tokenSnapshot.totalBalanceUSD = token.totalBalanceUSD;
-  tokenSnapshot.volumeNotional = token.totalVolumeNotional;
-  tokenSnapshot.volumeUSD = token.totalVolumeUSD;
+  tokenSnapshot.totalVolumeNotional = token.totalVolumeNotional;
+  tokenSnapshot.totalVolumeUSD = token.totalVolumeUSD;
   tokenSnapshot.save();
 }
 

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -122,6 +122,8 @@ export function createPoolTokenEntity(poolId: string, tokenAddress: Address): vo
   }
 
   let poolToken = new PoolToken(poolTokenId);
+  // ensures token entity is created
+  let _token = getToken(tokenAddress);
   poolToken.poolId = poolId;
   poolToken.address = tokenAddress.toHexString();
   poolToken.name = name;
@@ -130,6 +132,7 @@ export function createPoolTokenEntity(poolId: string, tokenAddress: Address): vo
   poolToken.balance = ZERO_BD;
   poolToken.invested = ZERO_BD;
   poolToken.priceRate = ONE_BD;
+  poolToken.token = _token.id;
   poolToken.save();
 }
 

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -295,29 +295,23 @@ export function updateTokenBalances(
   event: SwapEvent
 ): void {
   let token = getToken(tokenAddress);
-  let tokenSnapshot = getTokenSnapshot(tokenAddress, event);
 
   if (swapDirection == SWAP_IN) {
     token.totalBalanceNotional = token.totalBalanceNotional.plus(notionalBalance);
-    tokenSnapshot.totalBalanceNotional = token.totalBalanceNotional;
-
     token.totalBalanceUSD = token.totalBalanceUSD.plus(usdBalance);
-    tokenSnapshot.totalBalanceUSD = token.totalBalanceUSD;
   } else if (swapDirection == SWAP_OUT) {
     token.totalBalanceNotional = token.totalBalanceNotional.minus(notionalBalance);
-    tokenSnapshot.totalBalanceNotional = token.totalBalanceNotional;
-
     token.totalBalanceUSD = token.totalBalanceUSD.minus(usdBalance);
-    tokenSnapshot.totalBalanceUSD = tokenSnapshot.totalBalanceUSD.minus(usdBalance);
   }
 
   token.totalVolumeUSD = token.totalVolumeUSD.plus(usdBalance);
-  tokenSnapshot.volumeUSD = tokenSnapshot.volumeUSD.plus(usdBalance);
-
-  token.totalVolumeNotional = token.totalVolumeNotional.plus(notionalBalance);
-  tokenSnapshot.volumeNotional = tokenSnapshot.volumeNotional.plus(notionalBalance);
-
   token.save();
+
+  let tokenSnapshot = getTokenSnapshot(tokenAddress, event);
+  tokenSnapshot.totalBalanceNotional = token.totalBalanceNotional;
+  tokenSnapshot.totalBalanceUSD = token.totalBalanceUSD;
+  tokenSnapshot.volumeNotional = token.totalVolumeNotional;
+  tokenSnapshot.volumeUSD = token.totalVolumeUSD;
   tokenSnapshot.save();
 }
 

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -12,9 +12,9 @@ import {
   TradePairSnapshot,
 } from '../../types/schema';
 import { ERC20 } from '../../types/Vault/ERC20';
+import { Swap as SwapEvent } from '../../types/Vault/Vault';
 import { ONE_BD, SWAP_IN, SWAP_OUT, ZERO, ZERO_BD } from './constants';
 import { getPoolAddress } from './pools';
-import { Swap as SwapEvent } from '../../types/Vault/Vault';
 
 const DAY = 24 * 60 * 60;
 

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -234,7 +234,6 @@ export function createToken(tokenAddress: Address): Token {
   token.totalSwapCount = ZERO;
   token.totalVolumeUSD = ZERO_BD;
   token.totalVolumeNotional = ZERO_BD;
-  token.poolCount = ZERO;
   token.address = tokenAddress.toHexString();
   token.save();
   return token;
@@ -261,11 +260,11 @@ export function getTokenSnapshot(tokenAddress: Address, event: ethereum.Event): 
     let token = getToken(tokenAddress);
     dayData = new TokenSnapshot(id);
     dayData.timestamp = dayStartTimestamp;
-    dayData.totalSwapCount = ZERO;
-    dayData.totalBalanceUSD = ZERO_BD;
-    dayData.totalBalanceNotional = ZERO_BD;
-    dayData.totalVolumeUSD = ZERO_BD;
-    dayData.totalVolumeNotional = ZERO_BD;
+    dayData.swapCount = ZERO;
+    dayData.balanceUSD = ZERO_BD;
+    dayData.balanceNotional = ZERO_BD;
+    dayData.volumeUSD = ZERO_BD;
+    dayData.volumeNotional = ZERO_BD;
     dayData.token = token.id;
     dayData.save();
   }
@@ -281,7 +280,7 @@ export function uptickSwapsForToken(tokenAddress: Address, event: ethereum.Event
 
   // update the snapshots
   let snapshot = getTokenSnapshot(tokenAddress, event);
-  snapshot.totalSwapCount = token.totalSwapCount.plus(BigInt.fromI32(1));
+  snapshot.swapCount = token.totalSwapCount.plus(BigInt.fromI32(1));
   snapshot.save();
 }
 

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -266,8 +266,8 @@ export function getTokenSnapshot(tokenAddress: Address, event: ethereum.Event): 
     dayData.totalSwapCount = token.totalSwapCount;
     dayData.totalBalanceUSD = token.totalBalanceUSD;
     dayData.totalBalanceNotional = token.totalBalanceNotional;
-    dayData.volumeUSD = ZERO_BD;
-    dayData.volumeNotional = ZERO_BD;
+    dayData.totalVolumeUSD = ZERO_BD;
+    dayData.totalVolumeNotional = ZERO_BD;
     dayData.token = token.id;
     dayData.save();
   }

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -1,9 +1,10 @@
-import { ZERO_BD } from './constants';
-import { scaleDown, loadPoolToken } from './misc';
+import { Address } from '@graphprotocol/graph-ts';
 
 import { Pool } from '../../types/schema';
 import { WeightedPool } from '../../types/templates/WeightedPool/WeightedPool';
-import { Address } from '@graphprotocol/graph-ts';
+
+import { ZERO_BD } from './constants';
+import { scaleDown, loadPoolToken } from './misc';
 
 export function updatePoolWeights(poolId: string): void {
   let pool = Pool.load(poolId);

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -183,7 +183,7 @@ function findOrInitializeVault(): Balancer {
   vault.totalLiquidity = ZERO_BD;
   vault.totalSwapVolume = ZERO_BD;
   vault.totalSwapFee = ZERO_BD;
-  return vault;
+  return vault as Balancer;
 }
 
 function handleNewPool(event: PoolCreated, poolId: Bytes, swapFee: BigInt): Pool {
@@ -217,5 +217,5 @@ function handleNewPool(event: PoolCreated, poolId: Bytes, swapFee: BigInt): Pool
     vault.save();
   }
 
-  return pool;
+  return pool as Pool;
 }

--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -38,7 +38,6 @@ export function updatePoolLiquidity(poolId: string, block: BigInt, pricingAsset:
     let price: BigDecimal;
     let latestPriceId = getLatestPriceId(tokenAddress, pricingAsset);
     let latestPrice = LatestPrice.load(latestPriceId);
-    let token = getToken(tokenAddress);
 
     if (tokenPrice == null && latestPrice != null) {
       price = latestPrice.price;
@@ -60,6 +59,7 @@ export function updatePoolLiquidity(poolId: string, block: BigInt, pricingAsset:
       latestPrice.poolId = poolId;
       latestPrice.save();
 
+      let token = getToken(tokenAddress);
       token.latestPrice = latestPrice.id;
       token.save();
     }

--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -1,5 +1,5 @@
 import { PRICING_ASSETS, USD_STABLE_ASSETS } from './helpers/constants';
-import { getTokenPriceId, loadPoolToken } from './helpers/misc';
+import { getToken, getTokenPriceId, loadPoolToken } from './helpers/misc';
 import { Address, Bytes, BigInt, BigDecimal } from '@graphprotocol/graph-ts';
 import { Pool, TokenPrice, Balancer, PoolHistoricalLiquidity, LatestPrice } from '../types/schema';
 import { ZERO_BD } from './helpers/constants';
@@ -38,6 +38,7 @@ export function updatePoolLiquidity(poolId: string, block: BigInt, pricingAsset:
     let price: BigDecimal;
     let latestPriceId = getLatestPriceId(tokenAddress, pricingAsset);
     let latestPrice = LatestPrice.load(latestPriceId);
+    let token = getToken(tokenAddress);
 
     if (tokenPrice == null && latestPrice != null) {
       price = latestPrice.price;
@@ -58,6 +59,9 @@ export function updatePoolLiquidity(poolId: string, block: BigInt, pricingAsset:
       latestPrice.block = block;
       latestPrice.poolId = poolId;
       latestPrice.save();
+
+      token.latestPrice = latestPrice.id;
+      token.save();
     }
     if (price) {
       let poolTokenValue = price.times(poolTokenQuantity);

--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -1,7 +1,7 @@
-import { PRICING_ASSETS, USD_STABLE_ASSETS } from './helpers/constants';
-import { getToken, getTokenPriceId, loadPoolToken } from './helpers/misc';
 import { Address, Bytes, BigInt, BigDecimal } from '@graphprotocol/graph-ts';
 import { Pool, TokenPrice, Balancer, PoolHistoricalLiquidity, LatestPrice } from '../types/schema';
+import { PRICING_ASSETS, USD_STABLE_ASSETS } from './helpers/constants';
+import { getToken, getTokenPriceId, loadPoolToken } from './helpers/misc';
 import { ZERO_BD } from './helpers/constants';
 
 export function isPricingAsset(asset: Address): boolean {

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -210,8 +210,8 @@ function handlePoolExited(event: PoolBalanceChanged): void {
     token.totalBalanceNotional = token.totalBalanceNotional.minus(tokenAmountOut);
     token.totalBalanceUSD = token.totalBalanceUSD.minus(tokenAmountOutUSD);
 
-    tokenSnapshot.balanceNotional = tokenSnapshot.balanceNotional.minus(tokenAmountOut);
-    tokenSnapshot.balanceUSD = tokenSnapshot.balanceUSD.minus(tokenAmountOutUSD);
+    tokenSnapshot.totalBalanceNotional = token.totalBalanceNotional;
+    tokenSnapshot.totalBalanceUSD = token.totalBalanceUSD;
 
     poolToken.balance = newAmount;
     poolToken.save();
@@ -278,7 +278,7 @@ export function handleSwapEvent(event: SwapEvent): void {
   createUserEntity(event.transaction.from);
   let poolId = event.params.poolId;
 
-  let pool = Pool.load(poolId.toHex());
+  let pool = Pool.load(poolId.toHex()) as Pool;
   if (pool == null) {
     log.warning('Pool not found in handleSwapEvent: {}', [poolId.toHexString()]);
     return;

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -131,14 +131,14 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
 
     token.totalBalanceNotional = token.totalBalanceNotional.plus(tokenAmountIn);
     token.totalBalanceUSD = token.totalBalanceUSD.plus(tokenAmountInUSD);
+    token.save();
 
     tokenSnapshot.totalBalanceNotional = token.totalBalanceNotional;
     tokenSnapshot.totalBalanceUSD = token.totalBalanceUSD;
+    tokenSnapshot.save();
 
     poolToken.balance = newAmount;
     poolToken.save();
-    token.save();
-    tokenSnapshot.save();
   }
 
   for (let i: i32 = 0; i < tokenAddresses.length; i++) {
@@ -209,14 +209,14 @@ function handlePoolExited(event: PoolBalanceChanged): void {
 
     token.totalBalanceNotional = token.totalBalanceNotional.minus(tokenAmountOut);
     token.totalBalanceUSD = token.totalBalanceUSD.minus(tokenAmountOutUSD);
+    token.save();
 
     tokenSnapshot.totalBalanceNotional = token.totalBalanceNotional;
     tokenSnapshot.totalBalanceUSD = token.totalBalanceUSD;
+    tokenSnapshot.save();
 
     poolToken.balance = newAmount;
     poolToken.save();
-    token.save();
-    tokenSnapshot.save();
   }
 
   for (let i: i32 = 0; i < tokenAddresses.length; i++) {

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -132,8 +132,8 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
     token.totalBalanceNotional = token.totalBalanceNotional.plus(tokenAmountIn);
     token.totalBalanceUSD = token.totalBalanceUSD.plus(tokenAmountInUSD);
 
-    tokenSnapshot.balanceNotional = tokenSnapshot.balanceNotional.plus(tokenAmountIn);
-    tokenSnapshot.balanceUSD = tokenSnapshot.balanceUSD.plus(tokenAmountInUSD);
+    tokenSnapshot.totalBalanceNotional = token.totalBalanceNotional;
+    tokenSnapshot.totalBalanceUSD = token.totalBalanceUSD;
 
     poolToken.balance = newAmount;
     poolToken.save();

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -370,8 +370,8 @@ export function handleSwapEvent(event: SwapEvent): void {
   tradePair.save();
 
   let tradePairSnapshot = getTradePairSnapshot(tradePair.id, blockTimestamp);
-  tradePairSnapshot.swapVolume = tradePairSnapshot.swapVolume.plus(swapValueUSD);
-  tradePairSnapshot.swapFee = tradePairSnapshot.swapFee.plus(swapFeesUSD);
+  tradePairSnapshot.totalSwapVolume = tradePair.totalSwapVolume.plus(swapValueUSD);
+  tradePairSnapshot.totalSwapFee = tradePair.totalSwapFee.plus(swapFeesUSD);
   tradePairSnapshot.save();
 
   if (swap.tokenAmountOut == ZERO_BD || swap.tokenAmountIn == ZERO_BD) {

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -205,6 +205,9 @@ function handlePoolExited(event: PoolBalanceChanged): void {
     let newAmount = poolToken.balance.minus(tokenAmountOut);
     let tokenAmountOutUSD = valueInUSD(tokenAmountOut, tokenAddress);
 
+    poolToken.balance = newAmount;
+    poolToken.save();
+
     let token = getToken(tokenAddress);
     token.totalBalanceNotional = token.totalBalanceNotional.minus(tokenAmountOut);
     token.totalBalanceUSD = token.totalBalanceUSD.minus(tokenAmountOutUSD);
@@ -214,9 +217,6 @@ function handlePoolExited(event: PoolBalanceChanged): void {
     tokenSnapshot.totalBalanceNotional = token.totalBalanceNotional;
     tokenSnapshot.totalBalanceUSD = token.totalBalanceUSD;
     tokenSnapshot.save();
-
-    poolToken.balance = newAmount;
-    poolToken.save();
   }
 
   for (let i: i32 = 0; i < tokenAddresses.length; i++) {

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -127,9 +127,13 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
     }
     let tokenAmountIn = tokenToDecimal(amounts[i], poolToken.decimals);
     let newAmount = poolToken.balance.plus(tokenAmountIn);
+    let tokenAmountInUSD = valueInUSD(tokenAmountIn, tokenAddress);
 
     token.totalBalanceNotional = token.totalBalanceNotional.plus(tokenAmountIn);
+    token.totalBalanceUSD = token.totalBalanceUSD.plus(tokenAmountInUSD);
+
     tokenSnapshot.balanceNotional = tokenSnapshot.balanceNotional.plus(tokenAmountIn);
+    tokenSnapshot.balanceUSD = tokenSnapshot.balanceUSD.plus(tokenAmountInUSD);
 
     poolToken.balance = newAmount;
     poolToken.save();
@@ -194,15 +198,20 @@ function handlePoolExited(event: PoolBalanceChanged): void {
     let poolToken = loadPoolToken(poolId, tokenAddress);
     let token = getToken(tokenAddress);
     let tokenSnapshot = getTokenSnapshot(tokenAddress, event);
+
     // adding initial liquidity
     if (poolToken == null) {
       throw new Error('poolToken not found');
     }
     let tokenAmountOut = tokenToDecimal(amounts[i].neg(), poolToken.decimals);
+    let tokenAmountOutUSD = valueInUSD(tokenAmountOut, tokenAddress);
     let newAmount = poolToken.balance.minus(tokenAmountOut);
 
     token.totalBalanceNotional = token.totalBalanceNotional.minus(tokenAmountOut);
+    token.totalBalanceUSD = token.totalBalanceUSD.minus(tokenAmountOutUSD);
+
     tokenSnapshot.balanceNotional = tokenSnapshot.balanceNotional.minus(tokenAmountOut);
+    tokenSnapshot.balanceUSD = tokenSnapshot.balanceUSD.minus(tokenAmountOutUSD);
 
     poolToken.balance = newAmount;
     poolToken.save();

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -24,10 +24,16 @@ import {
   createUserEntity,
   getTokenDecimals,
   loadPoolToken,
+  getToken,
+  getTokenSnapshot,
+  uptickSwapsForToken,
+  updateTokenBalances,
+  getTradePairSnapshot,
+  getTradePair,
 } from './helpers/misc';
 import { updatePoolWeights } from './helpers/weighted';
 import { isUSDStable, isPricingAsset, updatePoolLiquidity, valueInUSD } from './pricing';
-import { ZERO, ZERO_BD } from './helpers/constants';
+import { SWAP_IN, SWAP_OUT, ZERO, ZERO_BD } from './helpers/constants';
 import { isVariableWeightPool } from './helpers/pools';
 
 /************************************
@@ -112,14 +118,23 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
   for (let i: i32 = 0; i < tokenAddresses.length; i++) {
     let tokenAddress: Address = Address.fromString(tokenAddresses[i].toHexString());
     let poolToken = loadPoolToken(poolId, tokenAddress);
+    let token = getToken(tokenAddress);
+    let tokenSnapshot = getTokenSnapshot(tokenAddress, event);
+
     // adding initial liquidity
     if (poolToken == null) {
       throw new Error('poolToken not found');
     }
     let tokenAmountIn = tokenToDecimal(amounts[i], poolToken.decimals);
     let newAmount = poolToken.balance.plus(tokenAmountIn);
+
+    token.totalBalanceNotional = token.totalBalanceNotional.plus(tokenAmountIn);
+    tokenSnapshot.balanceNotional = tokenSnapshot.balanceNotional.plus(tokenAmountIn);
+
     poolToken.balance = newAmount;
     poolToken.save();
+    token.save();
+    tokenSnapshot.save();
   }
 
   for (let i: i32 = 0; i < tokenAddresses.length; i++) {
@@ -177,14 +192,22 @@ function handlePoolExited(event: PoolBalanceChanged): void {
   for (let i: i32 = 0; i < tokenAddresses.length; i++) {
     let tokenAddress: Address = Address.fromString(tokenAddresses[i].toHexString());
     let poolToken = loadPoolToken(poolId, tokenAddress);
+    let token = getToken(tokenAddress);
+    let tokenSnapshot = getTokenSnapshot(tokenAddress, event);
     // adding initial liquidity
     if (poolToken == null) {
       throw new Error('poolToken not found');
     }
     let tokenAmountOut = tokenToDecimal(amounts[i].neg(), poolToken.decimals);
     let newAmount = poolToken.balance.minus(tokenAmountOut);
+
+    token.totalBalanceNotional = token.totalBalanceNotional.minus(tokenAmountOut);
+    tokenSnapshot.balanceNotional = tokenSnapshot.balanceNotional.minus(tokenAmountOut);
+
     poolToken.balance = newAmount;
     poolToken.save();
+    token.save();
+    tokenSnapshot.save();
   }
 
   for (let i: i32 = 0; i < tokenAddresses.length; i++) {
@@ -321,6 +344,26 @@ export function handleSwapEvent(event: SwapEvent): void {
   let newOutAmount = poolTokenOut.balance.minus(tokenAmountOut);
   poolTokenOut.balance = newOutAmount;
   poolTokenOut.save();
+
+  // update swap counts for token
+  // updates token snapshots as well
+  uptickSwapsForToken(tokenInAddress, event);
+  uptickSwapsForToken(tokenOutAddress, event);
+
+  // update volume and balances for the tokens
+  // updates token snapshots as well
+  updateTokenBalances(tokenInAddress, swapValueUSD, tokenAmountIn, SWAP_IN, event);
+  updateTokenBalances(tokenOutAddress, swapValueUSD, tokenAmountOut, SWAP_OUT, event);
+
+  let tradePair = getTradePair(tokenInAddress, tokenOutAddress);
+  tradePair.totalSwapVolume = tradePair.totalSwapVolume.plus(swapValueUSD);
+  tradePair.totalSwapFee = tradePair.totalSwapFee.plus(swapFeesUSD);
+  tradePair.save();
+
+  let tradePairSnapshot = getTradePairSnapshot(tradePair.id, blockTimestamp);
+  tradePairSnapshot.swapVolume = tradePairSnapshot.swapVolume.plus(swapValueUSD);
+  tradePairSnapshot.swapFee = tradePairSnapshot.swapFee.plus(swapFeesUSD);
+  tradePairSnapshot.save();
 
   if (swap.tokenAmountOut == ZERO_BD || swap.tokenAmountIn == ZERO_BD) {
     return;

--- a/subgraph.arbitrum.yaml
+++ b/subgraph.arbitrum.yaml
@@ -22,6 +22,10 @@ dataSources:
         - PoolToken
         - User
         - UserInternalBalance
+        - Token
+        - TokenSnapshot
+        - TradePair
+        - TradePairSnapshot
       abis:
         - name: Vault
           file: ./abis/Vault.json

--- a/subgraph.goerli.yaml
+++ b/subgraph.goerli.yaml
@@ -22,6 +22,10 @@ dataSources:
         - PoolToken
         - User
         - UserInternalBalance
+        - Token
+        - TokenSnapshot
+        - TradePair
+        - TradePairSnapshot
       abis:
         - name: Vault
           file: ./abis/Vault.json

--- a/subgraph.kovan.yaml
+++ b/subgraph.kovan.yaml
@@ -22,6 +22,10 @@ dataSources:
         - PoolToken
         - User
         - UserInternalBalance
+        - Token
+        - TokenSnapshot
+        - TradePair
+        - TradePairSnapshot
       abis:
         - name: Vault
           file: ./abis/Vault.json

--- a/subgraph.polygon.yaml
+++ b/subgraph.polygon.yaml
@@ -22,6 +22,10 @@ dataSources:
         - PoolToken
         - User
         - UserInternalBalance
+        - Token
+        - TokenSnapshot
+        - TradePair
+        - TradePairSnapshot
       abis:
         - name: Vault
           file: ./abis/Vault.json

--- a/subgraph.rinkeby.yaml
+++ b/subgraph.rinkeby.yaml
@@ -22,6 +22,10 @@ dataSources:
         - PoolToken
         - User
         - UserInternalBalance
+        - Token
+        - TokenSnapshot
+        - TradePair
+        - TradePairSnapshot
       abis:
         - name: Vault
           file: ./abis/Vault.json

--- a/subgraph.ropsten.yaml
+++ b/subgraph.ropsten.yaml
@@ -22,6 +22,10 @@ dataSources:
         - PoolToken
         - User
         - UserInternalBalance
+        - Token
+        - TokenSnapshot
+        - TradePair
+        - TradePairSnapshot
       abis:
         - name: Vault
           file: ./abis/Vault.json

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -22,6 +22,10 @@ dataSources:
         - PoolToken
         - User
         - UserInternalBalance
+        - Token
+        - TokenSnapshot
+        - TradePair
+        - TradePairSnapshot
       abis:
         - name: Vault
           file: ./abis/Vault.json

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -22,6 +22,10 @@ dataSources:
         - PoolToken
         - User
         - UserInternalBalance
+        - Token
+        - TokenSnapshot
+        - TradePair
+        - TradePairSnapshot
       abis:
         - name: Vault
           file: ./abis/Vault.json


### PR DESCRIPTION
This pull request introduces the following entities.

`Token` - A simple ERC20 token wrapper entity. But it also tracks volume and balance across the platform for this token. There is a bit of duplication between `PoolToken` but the idea is that eventually the ERC20 information will be removed from there once we get deprecation down.

`TokenSnapshot` - Daily snapshot of the statistics which are tracked in `Token`'

`TradePair` - Like a `Swap` entity, but tracks the totals for that particular pair

`TradePairSnapshot` - Daily snapshot of the statistics tracked in `TradePair`