### PR TITLE
Add balancer vault historical entities

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -7,7 +7,7 @@ type Balancer @entity {
   totalLiquidity: BigDecimal!
   totalSwapVolume: BigDecimal!
   totalSwapFee: BigDecimal!
-  totalSwapCount: BigDecimal!
+  totalSwapCount: BigInt!
 }
 
 type Pool @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -7,6 +7,7 @@ type Balancer @entity {
   totalLiquidity: BigDecimal!
   totalSwapVolume: BigDecimal!
   totalSwapFee: BigDecimal!
+  totalSwapCount: BigDecimal!
 }
 
 type Pool @entity {
@@ -196,4 +197,15 @@ type PoolSnapshot @entity {
   swapVolume: BigDecimal!
   swapFees: BigDecimal!
   timestamp: Int!
+}
+
+type BalancerSnapshot @entity {
+  id: ID!
+  vault: Balancer!
+  timestamp: Int!
+  poolCount: Int!
+  totalLiquidity: BigDecimal!
+  totalSwapCount: BigInt!
+  totalSwapVolume: BigDecimal!
+  totalSwapFee: BigDecimal!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -5,9 +5,9 @@ type Balancer @entity {
   pools: [Pool!] @derivedFrom(field: "vaultID")
 
   totalLiquidity: BigDecimal!
+  totalSwapCount: BigInt!
   totalSwapVolume: BigDecimal!
   totalSwapFee: BigDecimal!
-  totalSwapCount: BigInt!
 }
 
 type Pool @entity {

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -1,5 +1,14 @@
 import { BigDecimal, Address, BigInt } from '@graphprotocol/graph-ts';
-import { Pool, User, PoolToken, PoolShare, PoolSnapshot, PriceRateProvider, BalancerSnapshot, Balancer } from '../../types/schema';
+import {
+  Pool,
+  User,
+  PoolToken,
+  PoolShare,
+  PoolSnapshot,
+  PriceRateProvider,
+  BalancerSnapshot,
+  Balancer,
+} from '../../types/schema';
 import { ERC20 } from '../../types/Vault/ERC20';
 import { ONE_BD, ZERO_BD } from './constants';
 import { getPoolAddress } from './pools';

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -1,5 +1,5 @@
 import { BigDecimal, Address, BigInt } from '@graphprotocol/graph-ts';
-import { Pool, User, PoolToken, PoolShare, PoolSnapshot, PriceRateProvider } from '../../types/schema';
+import { Pool, User, PoolToken, PoolShare, PoolSnapshot, PriceRateProvider, BalancerSnapshot, Balancer } from '../../types/schema';
 import { ERC20 } from '../../types/Vault/ERC20';
 import { ONE_BD, ZERO_BD } from './constants';
 import { getPoolAddress } from './pools';
@@ -196,4 +196,28 @@ export function createUserEntity(address: Address): void {
     let user = new User(addressHex);
     user.save();
   }
+}
+
+export function getBalancerSnapshot(vaultId: string, timestamp: i32): BalancerSnapshot {
+  let dayID = timestamp / 86400;
+  let id = vaultId + '-' + dayID.toString();
+  let snapshot = BalancerSnapshot.load(id);
+  // we know that the vault should be created by this call
+  let vault = Balancer.load('2') as Balancer;
+
+  if (snapshot == null) {
+    let dayStartTimestamp = dayID * 86400;
+    snapshot = new BalancerSnapshot(id);
+    snapshot.poolCount = 0;
+
+    snapshot.totalLiquidity = vault.totalLiquidity;
+    snapshot.totalSwapFee = vault.totalSwapFee;
+    snapshot.totalSwapVolume = vault.totalSwapVolume;
+    snapshot.totalSwapCount = vault.totalSwapCount;
+    snapshot.vault = vaultId;
+    snapshot.timestamp = dayStartTimestamp;
+    snapshot.save();
+  }
+
+  return snapshot as BalancerSnapshot;
 }

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -208,7 +208,7 @@ export function getBalancerSnapshot(vaultId: string, timestamp: i32): BalancerSn
   if (snapshot == null) {
     let dayStartTimestamp = dayID * 86400;
     snapshot = new BalancerSnapshot(id);
-    snapshot.poolCount = 0;
+    snapshot.poolCount = vault.poolCount;
 
     snapshot.totalLiquidity = vault.totalLiquidity;
     snapshot.totalSwapFee = vault.totalSwapFee;

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -211,12 +211,12 @@ export function getBalancerSnapshot(vaultId: string, timestamp: i32): BalancerSn
   let dayID = timestamp / 86400;
   let id = vaultId + '-' + dayID.toString();
   let snapshot = BalancerSnapshot.load(id);
-  // we know that the vault should be created by this call
-  let vault = Balancer.load('2') as Balancer;
 
   if (snapshot == null) {
     let dayStartTimestamp = dayID * 86400;
     snapshot = new BalancerSnapshot(id);
+    // we know that the vault should be created by this call
+    let vault = Balancer.load('2') as Balancer;
     snapshot.poolCount = vault.poolCount;
 
     snapshot.totalLiquidity = vault.totalLiquidity;

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -1,7 +1,7 @@
 import { ZERO_BD, VAULT_ADDRESS } from './helpers/constants';
 import { PoolType } from './helpers/pools';
 
-import { newPoolEntity, createPoolTokenEntity, scaleDown } from './helpers/misc';
+import { newPoolEntity, createPoolTokenEntity, scaleDown, getBalancerSnapshot } from './helpers/misc';
 import { updatePoolWeights } from './helpers/weighted';
 
 import { BigInt, Address, Bytes } from '@graphprotocol/graph-ts';
@@ -183,6 +183,7 @@ function findOrInitializeVault(): Balancer {
   vault.totalLiquidity = ZERO_BD;
   vault.totalSwapVolume = ZERO_BD;
   vault.totalSwapFee = ZERO_BD;
+  vault.totalSwapCount = ZERO_BD;
   return vault;
 }
 
@@ -213,7 +214,11 @@ function handleNewPool(event: PoolCreated, poolId: Bytes, swapFee: BigInt): Pool
     pool.save();
 
     let vault = findOrInitializeVault();
+    let vaultSnapshot = getBalancerSnapshot(vault.id, event.block.timestamp.toI32());
+    
     vault.poolCount += 1;
+    vaultSnapshot.poolCount += 1;
+    vaultSnapshot.save();
     vault.save();
   }
 

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -215,7 +215,7 @@ function handleNewPool(event: PoolCreated, poolId: Bytes, swapFee: BigInt): Pool
 
     let vault = findOrInitializeVault();
     let vaultSnapshot = getBalancerSnapshot(vault.id, event.block.timestamp.toI32());
-    
+
     vault.poolCount += 1;
     vault.save();
 

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -217,9 +217,10 @@ function handleNewPool(event: PoolCreated, poolId: Bytes, swapFee: BigInt): Pool
     let vaultSnapshot = getBalancerSnapshot(vault.id, event.block.timestamp.toI32());
     
     vault.poolCount += 1;
+    vault.save();
+
     vaultSnapshot.poolCount += 1;
     vaultSnapshot.save();
-    vault.save();
   }
 
   return pool;

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -1,4 +1,4 @@
-import { ZERO_BD, VAULT_ADDRESS } from './helpers/constants';
+import { ZERO_BD, VAULT_ADDRESS, ZERO } from './helpers/constants';
 import { PoolType } from './helpers/pools';
 
 import { newPoolEntity, createPoolTokenEntity, scaleDown, getBalancerSnapshot } from './helpers/misc';
@@ -183,7 +183,7 @@ function findOrInitializeVault(): Balancer {
   vault.totalLiquidity = ZERO_BD;
   vault.totalSwapVolume = ZERO_BD;
   vault.totalSwapFee = ZERO_BD;
-  vault.totalSwapCount = ZERO_BD;
+  vault.totalSwapCount = ZERO;
   return vault;
 }
 

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -214,11 +214,10 @@ function handleNewPool(event: PoolCreated, poolId: Bytes, swapFee: BigInt): Pool
     pool.save();
 
     let vault = findOrInitializeVault();
-    let vaultSnapshot = getBalancerSnapshot(vault.id, event.block.timestamp.toI32());
-
     vault.poolCount += 1;
     vault.save();
 
+    let vaultSnapshot = getBalancerSnapshot(vault.id, event.block.timestamp.toI32());
     vaultSnapshot.poolCount += 1;
     vaultSnapshot.save();
   }

--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -95,9 +95,9 @@ export function updatePoolLiquidity(poolId: string, block: BigInt, pricingAsset:
   let liquidityChange: BigDecimal = newPoolLiquidity.minus(oldPoolLiquidity);
 
   vault.totalLiquidity = vault.totalLiquidity.plus(liquidityChange);
-  vaultSnapshot.totalLiquidity = vault.totalLiquidity;
-
   vault.save();
+
+  vaultSnapshot.totalLiquidity = vault.totalLiquidity;
   vaultSnapshot.save();
 
   return true;

--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -67,6 +67,7 @@ export function updatePoolLiquidity(poolId: string, block: BigInt, pricingAsset:
 
   let oldPoolLiquidity: BigDecimal = pool.totalLiquidity;
   let newPoolLiquidity: BigDecimal = valueInUSD(poolValue, pricingAsset) || ZERO_BD;
+  let liquidityChange: BigDecimal = newPoolLiquidity.minus(oldPoolLiquidity);
 
   // If the pool isn't empty but we have a zero USD value then it's likely that we have a bad pricing asset
   // Don't commit any changes and just report the failure.
@@ -91,12 +92,10 @@ export function updatePoolLiquidity(poolId: string, block: BigInt, pricingAsset:
 
   // Update global stats
   let vault = Balancer.load('2') as Balancer;
-  let vaultSnapshot = getBalancerSnapshot(vault.id, timestamp);
-  let liquidityChange: BigDecimal = newPoolLiquidity.minus(oldPoolLiquidity);
-
   vault.totalLiquidity = vault.totalLiquidity.plus(liquidityChange);
   vault.save();
 
+  let vaultSnapshot = getBalancerSnapshot(vault.id, timestamp);
   vaultSnapshot.totalLiquidity = vault.totalLiquidity;
   vaultSnapshot.save();
 

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -309,7 +309,7 @@ export function handleSwapEvent(event: SwapEvent): void {
 
   vault.totalSwapVolume = vault.totalSwapVolume.plus(swapValueUSD);
   vault.totalSwapFee = vault.totalSwapFee.plus(swapFeesUSD);
-  vault.totalSwapCount = vault.totalSwapCount.plus(ONE_BD);
+  vault.totalSwapCount = vault.totalSwapCount.plus(BigInt.fromI32(1));
 
   vault.totalSwapVolume = vault.totalSwapVolume;
   vault.totalSwapFee = vault.totalSwapFee;

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -28,7 +28,7 @@ import {
 } from './helpers/misc';
 import { updatePoolWeights } from './helpers/weighted';
 import { isPricingAsset, updatePoolLiquidity, valueInUSD } from './pricing';
-import { ONE_BD, ZERO, ZERO_BD } from './helpers/constants';
+import { ZERO, ZERO_BD } from './helpers/constants';
 import { isVariableWeightPool } from './helpers/pools';
 
 /************************************
@@ -310,13 +310,12 @@ export function handleSwapEvent(event: SwapEvent): void {
   vault.totalSwapVolume = vault.totalSwapVolume.plus(swapValueUSD);
   vault.totalSwapFee = vault.totalSwapFee.plus(swapFeesUSD);
   vault.totalSwapCount = vault.totalSwapCount.plus(BigInt.fromI32(1));
-
-  vault.totalSwapVolume = vault.totalSwapVolume;
-  vault.totalSwapFee = vault.totalSwapFee;
-  vault.totalSwapCount = vault.totalSwapCount;
-
-  vaultSnapshot.save();
   vault.save();
+
+  vaultSnapshot.totalSwapVolume = vault.totalSwapVolume;
+  vaultSnapshot.totalSwapFee = vault.totalSwapFee;
+  vaultSnapshot.totalSwapCount = vault.totalSwapCount;
+  vaultSnapshot.save();
 
   let newInAmount = poolTokenIn.balance.plus(tokenAmountIn);
   poolTokenIn.balance = newInAmount;

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -305,13 +305,12 @@ export function handleSwapEvent(event: SwapEvent): void {
 
   // update vault total swap volume
   let vault = Balancer.load('2') as Balancer;
-  let vaultSnapshot = getBalancerSnapshot(vault.id, blockTimestamp);
-
   vault.totalSwapVolume = vault.totalSwapVolume.plus(swapValueUSD);
   vault.totalSwapFee = vault.totalSwapFee.plus(swapFeesUSD);
   vault.totalSwapCount = vault.totalSwapCount.plus(BigInt.fromI32(1));
   vault.save();
 
+  let vaultSnapshot = getBalancerSnapshot(vault.id, blockTimestamp);
   vaultSnapshot.totalSwapVolume = vault.totalSwapVolume;
   vaultSnapshot.totalSwapFee = vault.totalSwapFee;
   vaultSnapshot.totalSwapCount = vault.totalSwapCount;

--- a/subgraph.arbitrum.yaml
+++ b/subgraph.arbitrum.yaml
@@ -22,6 +22,7 @@ dataSources:
         - PoolToken
         - User
         - UserInternalBalance
+        - BalancerSnapshot
       abis:
         - name: Vault
           file: ./abis/Vault.json

--- a/subgraph.goerli.yaml
+++ b/subgraph.goerli.yaml
@@ -22,6 +22,7 @@ dataSources:
         - PoolToken
         - User
         - UserInternalBalance
+        - BalancerSnapshot
       abis:
         - name: Vault
           file: ./abis/Vault.json

--- a/subgraph.kovan.yaml
+++ b/subgraph.kovan.yaml
@@ -22,6 +22,7 @@ dataSources:
         - PoolToken
         - User
         - UserInternalBalance
+        - BalancerSnapshot
       abis:
         - name: Vault
           file: ./abis/Vault.json

--- a/subgraph.polygon.yaml
+++ b/subgraph.polygon.yaml
@@ -22,6 +22,7 @@ dataSources:
         - PoolToken
         - User
         - UserInternalBalance
+        - BalancerSnapshot
       abis:
         - name: Vault
           file: ./abis/Vault.json

--- a/subgraph.rinkeby.yaml
+++ b/subgraph.rinkeby.yaml
@@ -22,6 +22,7 @@ dataSources:
         - PoolToken
         - User
         - UserInternalBalance
+        - BalancerSnapshot
       abis:
         - name: Vault
           file: ./abis/Vault.json

--- a/subgraph.ropsten.yaml
+++ b/subgraph.ropsten.yaml
@@ -22,6 +22,7 @@ dataSources:
         - PoolToken
         - User
         - UserInternalBalance
+        - BalancerSnapshot
       abis:
         - name: Vault
           file: ./abis/Vault.json

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -22,6 +22,7 @@ dataSources:
         - PoolToken
         - User
         - UserInternalBalance
+        - BalancerSnapshot
       abis:
         - name: Vault
           file: ./abis/Vault.json

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -22,6 +22,7 @@ dataSources:
         - PoolToken
         - User
         - UserInternalBalance
+        - BalancerSnapshot
       abis:
         - name: Vault
           file: ./abis/Vault.json


### PR DESCRIPTION
As per title. Add in the `BalancerSnapshot` entity which tracks the totals across each day. Volume between each day can be determined by the difference in totals day by day which is calculated by the consumers (clients, frontends). This entity just makes it easy to query historical data via the timestamp.