### PR TITLE
Make USD stable tokens take precedence over others in defining swapValueUSD

### DIFF
--- a/networks.yaml
+++ b/networks.yaml
@@ -18,9 +18,9 @@ mainnet:
   LiquidityBootstrappingPoolFactory:
     address: "0x751A0bC0e3f75b38e01Cf25bFCE7fF36DE1C87DE"
     startBlock: 12871780
-  # InvestmentPoolFactory:
-  #   address: ""
-  #   startBlock: 0
+  InvestmentPoolFactory:
+    address: "0x48767F9F868a4A7b86A90736632F6E44C2df7fa9"
+    startBlock: 13279079
   ConvergentPoolFactory:
     address: "0xb7561f547F3207eDb42A6AfA42170Cd47ADD17BD"
     startBlock: 12686198
@@ -146,9 +146,9 @@ polygon:
   # LiquidityBootstrappingPoolFactory:
   #   address: "0x751A0bC0e3f75b38e01Cf25bFCE7fF36DE1C87DE"
   #   startBlock: 17116402
-  # InvestmentPoolFactory:
-  #   address: ""
-  #   startBlock: 0
+  InvestmentPoolFactory:
+    address: "0x0f7bb7ce7b6ed9366F9b6B910AdeFE72dC538193"
+    startBlock: 19404118
   # ConvergentPoolFactory:
   #   address: ""
   #   startBlock: 0
@@ -172,9 +172,9 @@ arbitrum:
   LiquidityBootstrappingPoolFactory:
     address: "0x142B9666a0a3A30477b052962ddA81547E7029ab"
     startBlock: 222870
-  # InvestmentPoolFactory:
-  #   address: ""
-  #   startBlock: 0
+  InvestmentPoolFactory:
+    address: "0xaCd615B3705B9c880E4E7293f1030B34e57B4c1c"
+    startBlock: 1488052
   # ConvergentPoolFactory:
   #   address: ""
   #   startBlock: 0

--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -125,7 +125,7 @@ function getPoolHistoricalLiquidityId(poolId: string, tokenAddress: Address, blo
   return poolId.concat('-').concat(tokenAddress.toHexString()).concat('-').concat(block.toString());
 }
 
-function isUSDStable(asset: Address): boolean {
+export function isUSDStable(asset: Address): boolean {
   for (let i: i32 = 0; i < USD_STABLE_ASSETS.length; i++) {
     if (USD_STABLE_ASSETS[i] == asset) return true;
   }

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -291,11 +291,9 @@ export function handleSwapEvent(event: SwapEvent): void {
   let swapValueUSD = ZERO_BD;
   if (isUSDStable(tokenOutAddress)) {
     swapValueUSD = valueInUSD(tokenAmountOut, tokenOutAddress);
-  }
-  else if (isUSDStable(tokenInAddress)) {
+  } else if (isUSDStable(tokenInAddress)) {
     swapValueUSD = valueInUSD(tokenAmountIn, tokenInAddress);
-  }
-  else {
+  } else {
     swapValueUSD = valueInUSD(tokenAmountOut, tokenOutAddress) || valueInUSD(tokenAmountIn, tokenInAddress) || ZERO_BD;
   }
 

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -26,7 +26,7 @@ import {
   loadPoolToken,
 } from './helpers/misc';
 import { updatePoolWeights } from './helpers/weighted';
-import { isPricingAsset, updatePoolLiquidity, valueInUSD } from './pricing';
+import { isUSDStable, isPricingAsset, updatePoolLiquidity, valueInUSD } from './pricing';
 import { ZERO, ZERO_BD } from './helpers/constants';
 import { isVariableWeightPool } from './helpers/pools';
 
@@ -288,8 +288,16 @@ export function handleSwapEvent(event: SwapEvent): void {
   swap.tx = transactionHash;
   swap.save();
 
-  let swapValueUSD =
-    valueInUSD(tokenAmountOut, tokenOutAddress) || valueInUSD(tokenAmountIn, tokenInAddress) || ZERO_BD;
+  let swapValueUSD = ZERO_BD;
+  if (isUSDStable(tokenOutAddress)) {
+    swapValueUSD = valueInUSD(tokenAmountOut, tokenOutAddress);
+  }
+  else if (isUSDStable(tokenInAddress)) {
+    swapValueUSD = valueInUSD(tokenAmountIn, tokenInAddress);
+  }
+  else {
+    swapValueUSD = valueInUSD(tokenAmountOut, tokenOutAddress) || valueInUSD(tokenAmountIn, tokenInAddress) || ZERO_BD;
+  }
 
   // update pool swapsCount
   // let pool = Pool.load(poolId.toHex());

--- a/subgraph.arbitrum.yaml
+++ b/subgraph.arbitrum.yaml
@@ -177,6 +177,35 @@ dataSources:
       eventHandlers:
         - event: PoolCreated(indexed address)
           handler: handleNewLiquidityBootstrappingPool
+  - kind: ethereum/contract
+    name: InvestmentPoolFactory
+    network: arbitrum-one
+    source:
+      address: '0xaCd615B3705B9c880E4E7293f1030B34e57B4c1c'
+      abi: InvestmentPoolFactory
+      startBlock: 1488052
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      file: ./src/mappings/poolFactory.ts
+      entities:
+        - Balancer
+        - Pool
+      abis:
+        - name: Vault
+          file: ./abis/Vault.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: WeightedPool
+          file: ./abis/WeightedPool.json
+        - name: InvestmentPoolFactory
+          file: ./abis/InvestmentPoolFactory.json
+        - name: InvestmentPool
+          file: ./abis/InvestmentPool.json
+      eventHandlers:
+        - event: PoolCreated(indexed address)
+          handler: handleNewInvestmentPool
 templates:
   - kind: ethereum/contract
     name: WeightedPool

--- a/subgraph.polygon.yaml
+++ b/subgraph.polygon.yaml
@@ -119,6 +119,35 @@ dataSources:
       eventHandlers:
         - event: PoolCreated(indexed address)
           handler: handleNewStablePool
+  - kind: ethereum/contract
+    name: InvestmentPoolFactory
+    network: matic
+    source:
+      address: '0x0f7bb7ce7b6ed9366F9b6B910AdeFE72dC538193'
+      abi: InvestmentPoolFactory
+      startBlock: 19404118
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      file: ./src/mappings/poolFactory.ts
+      entities:
+        - Balancer
+        - Pool
+      abis:
+        - name: Vault
+          file: ./abis/Vault.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: WeightedPool
+          file: ./abis/WeightedPool.json
+        - name: InvestmentPoolFactory
+          file: ./abis/InvestmentPoolFactory.json
+        - name: InvestmentPool
+          file: ./abis/InvestmentPool.json
+      eventHandlers:
+        - event: PoolCreated(indexed address)
+          handler: handleNewInvestmentPool
 templates:
   - kind: ethereum/contract
     name: WeightedPool

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -178,6 +178,35 @@ dataSources:
         - event: PoolCreated(indexed address)
           handler: handleNewLiquidityBootstrappingPool
   - kind: ethereum/contract
+    name: InvestmentPoolFactory
+    network: mainnet
+    source:
+      address: '0x48767F9F868a4A7b86A90736632F6E44C2df7fa9'
+      abi: InvestmentPoolFactory
+      startBlock: 13279079
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      file: ./src/mappings/poolFactory.ts
+      entities:
+        - Balancer
+        - Pool
+      abis:
+        - name: Vault
+          file: ./abis/Vault.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: WeightedPool
+          file: ./abis/WeightedPool.json
+        - name: InvestmentPoolFactory
+          file: ./abis/InvestmentPoolFactory.json
+        - name: InvestmentPool
+          file: ./abis/InvestmentPool.json
+      eventHandlers:
+        - event: PoolCreated(indexed address)
+          handler: handleNewInvestmentPool
+  - kind: ethereum/contract
     name: ConvergentPoolFactory
     network: mainnet
     source:


### PR DESCRIPTION
When one of the tokens in a swap is a USDStable token, we can make it so that it takes precedence over the other so as to increase accuracy of `totalSwapVolume`. For example, in a `tokenA/USDC` pool, `totalSwapVolume` should equal the sum of all the USDC in or out of the pool over all swaps.