### PR TITLE
Make USD stable tokens take precedence over others in defining `swapValueUSD`

### DIFF
--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -125,7 +125,7 @@ function getPoolHistoricalLiquidityId(poolId: string, tokenAddress: Address, blo
   return poolId.concat('-').concat(tokenAddress.toHexString()).concat('-').concat(block.toString());
 }
 
-function isUSDStable(asset: Address): boolean {
+export function isUSDStable(asset: Address): boolean {
   for (let i: i32 = 0; i < USD_STABLE_ASSETS.length; i++) {
     if (USD_STABLE_ASSETS[i] == asset) return true;
   }

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -26,7 +26,7 @@ import {
   loadPoolToken,
 } from './helpers/misc';
 import { updatePoolWeights } from './helpers/weighted';
-import { isPricingAsset, updatePoolLiquidity, valueInUSD } from './pricing';
+import { isUSDStable, isPricingAsset, updatePoolLiquidity, valueInUSD } from './pricing';
 import { ZERO, ZERO_BD } from './helpers/constants';
 import { isVariableWeightPool } from './helpers/pools';
 
@@ -288,8 +288,14 @@ export function handleSwapEvent(event: SwapEvent): void {
   swap.tx = transactionHash;
   swap.save();
 
-  let swapValueUSD =
-    valueInUSD(tokenAmountOut, tokenOutAddress) || valueInUSD(tokenAmountIn, tokenInAddress) || ZERO_BD;
+  let swapValueUSD = ZERO_BD;
+  if (isUSDStable(tokenOutAddress)) {
+    swapValueUSD = valueInUSD(tokenAmountOut, tokenOutAddress);
+  } else if (isUSDStable(tokenInAddress)) {
+    swapValueUSD = valueInUSD(tokenAmountIn, tokenInAddress);
+  } else {
+    swapValueUSD = valueInUSD(tokenAmountOut, tokenOutAddress) || valueInUSD(tokenAmountIn, tokenInAddress) || ZERO_BD;
+  }
 
   // update pool swapsCount
   // let pool = Pool.load(poolId.toHex());


### PR DESCRIPTION
When one of the tokens in a swap is a USDStable token, we can make it so that it takes precedence over the other so as to increase accuracy of `totalSwapVolume`. For example, in a `tokenA/USDC` pool, `totalSwapVolume` should equal the sum of all the USDC in or out of the pool over all swaps.