### PR TITLE
Add tracking for amplification factor updates

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -119,6 +119,16 @@ type GradualWeightUpdate @entity {
   endWeights: [BigInt!]!
 }
 
+type AmpUpdate @entity {
+  id: ID!
+  poolId: Pool!
+  scheduledTimestamp: Int!
+  startTimestamp: Int!
+  endTimestamp: Int!
+  startAmp: BigInt!
+  endAmp: BigInt!
+}
+
 type Swap @entity {
   id: ID!
   caller: Bytes!

--- a/src/mappings/helpers/pools.ts
+++ b/src/mappings/helpers/pools.ts
@@ -15,6 +15,10 @@ export function isVariableWeightPool(pool: Pool): boolean {
   return pool.poolType == PoolType.LiquidityBootstrapping || pool.poolType == PoolType.Investment;
 }
 
+export function isStableLikePool(pool: Pool): boolean {
+  return pool.poolType == PoolType.Stable || pool.poolType == PoolType.MetaStable;
+}
+
 export function getPoolAddress(poolId: string): Address {
   return changetype<Address>(Address.fromHexString(poolId.slice(0, 42)));
 }

--- a/src/mappings/helpers/stable.ts
+++ b/src/mappings/helpers/stable.ts
@@ -1,6 +1,15 @@
-import { BigInt } from '@graphprotocol/graph-ts';
+import { Address, BigInt } from '@graphprotocol/graph-ts';
+import { Pool } from '../../types/schema';
 import { StablePool } from '../../types/templates/StablePool/StablePool';
 import { ZERO } from './constants';
+
+export function updateAmpFactor(pool: Pool): void {
+  let poolContract = StablePool.bind(changetype<Address>(pool.address));
+
+  pool.amp = getAmp(poolContract);
+
+  pool.save();
+}
 
 // TODO: allow passing MetaStablePool once AS supports union types
 export function getAmp(poolContract: StablePool): BigInt {

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -7,11 +7,13 @@ import {
 } from '../types/templates/LiquidityBootstrappingPool/LiquidityBootstrappingPool';
 import { ManagementFeePercentageChanged } from '../types/templates/InvestmentPool/InvestmentPool';
 import {
+  AmpUpdateStarted,
+  AmpUpdateStopped,
   MetaStablePool,
   PriceRateCacheUpdated,
   PriceRateProviderSet,
 } from '../types/templates/MetaStablePool/MetaStablePool';
-import { Pool, PriceRateProvider, GradualWeightUpdate } from '../types/schema';
+import { Pool, PriceRateProvider, GradualWeightUpdate, AmpUpdate } from '../types/schema';
 
 import {
   tokenToDecimal,
@@ -62,6 +64,48 @@ export function handleGradualWeightUpdateScheduled(event: GradualWeightUpdateSch
   weightUpdate.startWeights = event.params.startWeights;
   weightUpdate.endWeights = event.params.endWeights;
   weightUpdate.save();
+}
+
+/************************************
+ *********** AMP UPDATES ************
+ ************************************/
+
+export function handleAmpUpdateStarted(event: AmpUpdateStarted): void {
+  let poolAddress = event.address;
+
+  // TODO - refactor so pool -> poolId doesn't require call
+  let poolContract = WeightedPool.bind(poolAddress);
+  let poolIdCall = poolContract.try_getPoolId();
+  let poolId = poolIdCall.value;
+
+  let id = event.transaction.hash.toHexString().concat(event.transactionLogIndex.toString());
+  let ampUpdate = new AmpUpdate(id);
+  ampUpdate.poolId = poolId.toHexString();
+  ampUpdate.scheduledTimestamp = event.block.timestamp.toI32();
+  ampUpdate.startTimestamp = event.params.startTime.toI32();
+  ampUpdate.endTimestamp = event.params.endTime.toI32();
+  ampUpdate.startAmp = event.params.startValue;
+  ampUpdate.endAmp = event.params.endValue;
+  ampUpdate.save();
+}
+
+export function handleAmpUpdateStopped(event: AmpUpdateStopped): void {
+  let poolAddress = event.address;
+
+  // TODO - refactor so pool -> poolId doesn't require call
+  let poolContract = WeightedPool.bind(poolAddress);
+  let poolIdCall = poolContract.try_getPoolId();
+  let poolId = poolIdCall.value;
+
+  let id = event.transaction.hash.toHexString().concat(event.transactionLogIndex.toString());
+  let ampUpdate = new AmpUpdate(id);
+  ampUpdate.poolId = poolId.toHexString();
+  ampUpdate.scheduledTimestamp = event.block.timestamp.toI32();
+  ampUpdate.startTimestamp = event.block.timestamp.toI32();
+  ampUpdate.endTimestamp = event.block.timestamp.toI32();
+  ampUpdate.startAmp = event.params.currentValue;
+  ampUpdate.endAmp = event.params.currentValue;
+  ampUpdate.save();
 }
 
 /************************************

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -28,7 +28,9 @@ import {
 import { updatePoolWeights } from './helpers/weighted';
 import { isUSDStable, isPricingAsset, updatePoolLiquidity, valueInUSD } from './pricing';
 import { ZERO, ZERO_BD } from './helpers/constants';
-import { isVariableWeightPool } from './helpers/pools';
+import { isStableLikePool, isVariableWeightPool } from './helpers/pools';
+import { getAmp, updateAmpFactor } from './helpers/stable';
+import { StablePool } from '../types/templates/StablePool/StablePool';
 
 /************************************
  ******** INTERNAL BALANCES *********
@@ -252,9 +254,12 @@ export function handleSwapEvent(event: SwapEvent): void {
     return;
   }
 
-  // Some pools' weights update over time so we need to update them after each swap
   if (isVariableWeightPool(pool)) {
+    // Some pools' weights update over time so we need to update them after each swap
     updatePoolWeights(poolId.toHexString());
+  } else if (isStableLikePool(pool)) {
+    // Stablelike pools' amplification factors update over time so we need to update them after each swap
+    updateAmpFactor(pool);
   }
 
   let tokenInAddress: Address = event.params.tokenIn;

--- a/subgraph.arbitrum.yaml
+++ b/subgraph.arbitrum.yaml
@@ -259,6 +259,10 @@ templates:
           handler: handleTransfer
         - event: SwapFeePercentageChanged(uint256)
           handler: handleSwapFeePercentageChange
+        - event: AmpUpdateStarted(uint256,uint256,uint256,uint256)
+          handler: handleAmpUpdateStarted
+        - event: AmpUpdateStopped(uint256)
+          handler: handleAmpUpdateStopped
   - kind: ethereum/contract
     name: MetaStablePool
     network: arbitrum-one

--- a/subgraph.goerli.yaml
+++ b/subgraph.goerli.yaml
@@ -172,6 +172,10 @@ templates:
           handler: handleTransfer
         - event: SwapFeePercentageChanged(uint256)
           handler: handleSwapFeePercentageChange
+        - event: AmpUpdateStarted(uint256,uint256,uint256,uint256)
+          handler: handleAmpUpdateStarted
+        - event: AmpUpdateStopped(uint256)
+          handler: handleAmpUpdateStopped
   - kind: ethereum/contract
     name: MetaStablePool
     network: goerli

--- a/subgraph.kovan.yaml
+++ b/subgraph.kovan.yaml
@@ -259,6 +259,10 @@ templates:
           handler: handleTransfer
         - event: SwapFeePercentageChanged(uint256)
           handler: handleSwapFeePercentageChange
+        - event: AmpUpdateStarted(uint256,uint256,uint256,uint256)
+          handler: handleAmpUpdateStarted
+        - event: AmpUpdateStopped(uint256)
+          handler: handleAmpUpdateStopped
   - kind: ethereum/contract
     name: MetaStablePool
     network: kovan

--- a/subgraph.polygon.yaml
+++ b/subgraph.polygon.yaml
@@ -230,6 +230,10 @@ templates:
           handler: handleTransfer
         - event: SwapFeePercentageChanged(uint256)
           handler: handleSwapFeePercentageChange
+        - event: AmpUpdateStarted(uint256,uint256,uint256,uint256)
+          handler: handleAmpUpdateStarted
+        - event: AmpUpdateStopped(uint256)
+          handler: handleAmpUpdateStopped
   - kind: ethereum/contract
     name: MetaStablePool
     network: matic

--- a/subgraph.rinkeby.yaml
+++ b/subgraph.rinkeby.yaml
@@ -203,6 +203,10 @@ templates:
           handler: handleTransfer
         - event: SwapFeePercentageChanged(uint256)
           handler: handleSwapFeePercentageChange
+        - event: AmpUpdateStarted(uint256,uint256,uint256,uint256)
+          handler: handleAmpUpdateStarted
+        - event: AmpUpdateStopped(uint256)
+          handler: handleAmpUpdateStopped
   - kind: ethereum/contract
     name: MetaStablePool
     network: rinkeby

--- a/subgraph.ropsten.yaml
+++ b/subgraph.ropsten.yaml
@@ -145,6 +145,10 @@ templates:
           handler: handleTransfer
         - event: SwapFeePercentageChanged(uint256)
           handler: handleSwapFeePercentageChange
+        - event: AmpUpdateStarted(uint256,uint256,uint256,uint256)
+          handler: handleAmpUpdateStarted
+        - event: AmpUpdateStopped(uint256)
+          handler: handleAmpUpdateStopped
   - kind: ethereum/contract
     name: MetaStablePool
     network: ropsten

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -296,6 +296,10 @@ templates:
           handler: handleTransfer
         - event: SwapFeePercentageChanged(uint256)
           handler: handleSwapFeePercentageChange
+        - event: AmpUpdateStarted(uint256,uint256,uint256,uint256)
+          handler: handleAmpUpdateStarted
+        - event: AmpUpdateStopped(uint256)
+          handler: handleAmpUpdateStopped
   - kind: ethereum/contract
     name: MetaStablePool
     network: {{network}}

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -286,6 +286,10 @@ templates:
           handler: handleTransfer
         - event: SwapFeePercentageChanged(uint256)
           handler: handleSwapFeePercentageChange
+        - event: AmpUpdateStarted(uint256,uint256,uint256,uint256)
+          handler: handleAmpUpdateStarted
+        - event: AmpUpdateStopped(uint256)
+          handler: handleAmpUpdateStopped
   - kind: ethereum/contract
     name: MetaStablePool
     network: mainnet


### PR DESCRIPTION
We currently don't track any updates to a stablepools amp factor past deployment. This PR adds similar behaviour to that used for weight updates