### PR TITLE
Linear pool support

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -59,6 +59,10 @@ type Pool @entity {
 
   # InvestmentPool Only
   managementFee: BigDecimal
+
+  # LinearPool Only
+  lowerTarget: BigDecimal
+  upperTarget: BigDecimal
 }
 
 type PoolToken @entity {

--- a/src/mappings/helpers/pools.ts
+++ b/src/mappings/helpers/pools.ts
@@ -6,6 +6,7 @@ export namespace PoolType {
   export const Weighted = 'Weighted';
   export const Stable = 'Stable';
   export const MetaStable = 'MetaStable';
+  export const Linear = 'Linear';
   export const Element = 'Element';
   export const LiquidityBootstrapping = 'LiquidityBootstrapping';
   export const Investment = 'Investment';

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -22,7 +22,7 @@ import { StablePool } from '../types/templates/StablePool/StablePool';
 import { ConvergentCurvePool } from '../types/templates/ConvergentCurvePool/ConvergentCurvePool';
 import { ERC20 } from '../types/Vault/ERC20';
 
-function createWeightedLikePool(event: PoolCreated, poolType: string): string {
+function createNewPool(event: PoolCreated, poolType: string): string {
   let poolAddress: Address = event.params.pool;
   let poolContract = WeightedPool.bind(poolAddress);
 
@@ -60,62 +60,27 @@ function createWeightedLikePool(event: PoolCreated, poolType: string): string {
 }
 
 export function handleNewWeightedPool(event: PoolCreated): void {
-  createWeightedLikePool(event, PoolType.Weighted);
+  createNewPool(event, PoolType.Weighted);
   WeightedPoolTemplate.create(event.params.pool);
 }
 
 export function handleNewLiquidityBootstrappingPool(event: PoolCreated): void {
-  createWeightedLikePool(event, PoolType.LiquidityBootstrapping);
+  createNewPool(event, PoolType.LiquidityBootstrapping);
   LiquidityBootstrappingPoolTemplate.create(event.params.pool);
 }
 
 export function handleNewInvestmentPool(event: PoolCreated): void {
-  createWeightedLikePool(event, PoolType.Investment);
+  createNewPool(event, PoolType.Investment);
   InvestmentPoolTemplate.create(event.params.pool);
 }
 
-function createStableLikePool(event: PoolCreated, poolType: string): string {
-  let poolAddress: Address = event.params.pool;
-  let poolContract = StablePool.bind(poolAddress);
-
-  let poolIdCall = poolContract.try_getPoolId();
-  let poolId = poolIdCall.value;
-
-  let swapFeeCall = poolContract.try_getSwapFeePercentage();
-  let swapFee = swapFeeCall.value;
-
-  let ownerCall = poolContract.try_getOwner();
-  let owner = ownerCall.value;
-
-  let pool = handleNewPool(event, poolId, swapFee);
-  pool.poolType = poolType;
-  pool.factory = event.address;
-  pool.owner = owner;
-
-  let vaultContract = Vault.bind(VAULT_ADDRESS);
-  let tokensCall = vaultContract.try_getPoolTokens(poolId);
-
-  if (!tokensCall.reverted) {
-    let tokens = tokensCall.value.value0;
-    pool.tokensList = changetype<Bytes[]>(tokens);
-
-    for (let i: i32 = 0; i < tokens.length; i++) {
-      createPoolTokenEntity(poolId.toHexString(), tokens[i]);
-    }
-  }
-
-  pool.save();
-
-  return poolId.toHexString();
-}
-
 export function handleNewStablePool(event: PoolCreated): void {
-  createStableLikePool(event, PoolType.Stable);
+  createNewPool(event, PoolType.Stable);
   StablePoolTemplate.create(event.params.pool);
 }
 
 export function handleNewMetaStablePool(event: PoolCreated): void {
-  createStableLikePool(event, PoolType.MetaStable);
+  createNewPool(event, PoolType.MetaStable);
   MetaStablePoolTemplate.create(event.params.pool);
 }
 

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -84,6 +84,11 @@ export function handleNewMetaStablePool(event: PoolCreated): void {
   MetaStablePoolTemplate.create(event.params.pool);
 }
 
+export function handleNewLinearPool(event: PoolCreated): void {
+  createNewPool(event, PoolType.Linear);
+  LinearPoolTemplate.create(event.params.pool);
+}
+
 export function handleNewCCPPool(event: PoolCreated): void {
   let poolAddress: Address = event.params.pool;
 

--- a/subgraph.arbitrum.yaml
+++ b/subgraph.arbitrum.yaml
@@ -121,6 +121,8 @@ dataSources:
           file: ./abis/ERC20.json
         - name: StablePoolFactory
           file: ./abis/StablePoolFactory.json
+        - name: WeightedPool
+          file: ./abis/WeightedPool.json
         - name: StablePool
           file: ./abis/StablePool.json
       eventHandlers:
@@ -148,8 +150,8 @@ dataSources:
           file: ./abis/ERC20.json
         - name: MetaStablePoolFactory
           file: ./abis/MetaStablePoolFactory.json
-        - name: StablePool
-          file: ./abis/StablePool.json
+        - name: WeightedPool
+          file: ./abis/WeightedPool.json
         - name: MetaStablePool
           file: ./abis/MetaStablePool.json
       eventHandlers:

--- a/subgraph.kovan.yaml
+++ b/subgraph.kovan.yaml
@@ -121,6 +121,8 @@ dataSources:
           file: ./abis/ERC20.json
         - name: StablePoolFactory
           file: ./abis/StablePoolFactory.json
+        - name: WeightedPool
+          file: ./abis/WeightedPool.json
         - name: StablePool
           file: ./abis/StablePool.json
       eventHandlers:
@@ -148,8 +150,8 @@ dataSources:
           file: ./abis/ERC20.json
         - name: MetaStablePoolFactory
           file: ./abis/MetaStablePoolFactory.json
-        - name: StablePool
-          file: ./abis/StablePool.json
+        - name: WeightedPool
+          file: ./abis/WeightedPool.json
         - name: MetaStablePool
           file: ./abis/MetaStablePool.json
       eventHandlers:

--- a/subgraph.polygon.yaml
+++ b/subgraph.polygon.yaml
@@ -121,6 +121,8 @@ dataSources:
           file: ./abis/ERC20.json
         - name: StablePoolFactory
           file: ./abis/StablePoolFactory.json
+        - name: WeightedPool
+          file: ./abis/WeightedPool.json
         - name: StablePool
           file: ./abis/StablePool.json
       eventHandlers:

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -161,6 +161,37 @@ dataSources:
         - event: PoolCreated(indexed address)
           handler: handleNewMetaStablePool
   {{/if}}
+  {{#if LinearPoolFactory}}
+  - kind: ethereum/contract
+    name: LinearPoolFactory
+    network: {{network}}
+    source:
+      address: '{{LinearPoolFactory.address}}'
+      abi: LinearPoolFactory
+      startBlock: {{LinearPoolFactory.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      file: ./src/mappings/poolFactory.ts
+      entities:
+        - Balancer
+        - Pool
+      abis:
+        - name: Vault
+          file: ./abis/Vault.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: LinearPoolFactory
+          file: ./abis/LinearPoolFactory.json
+        - name: WeightedPool
+          file: ./abis/WeightedPool.json
+        - name: LinearPool
+          file: ./abis/LinearPool.json
+      eventHandlers:
+        - event: PoolCreated(indexed address)
+          handler: handleNewLinearPool
+  {{/if}}
   {{#if LiquidityBootstrappingPoolFactory}}
   - kind: ethereum/contract
     name: LiquidityBootstrappingPoolFactory
@@ -330,6 +361,38 @@ templates:
           file: ./abis/WeightedPool.json
         - name: MetaStablePool
           file: ./abis/MetaStablePool.json
+        - name: BalancerPoolToken
+          file: ./abis/BalancerPoolToken.json
+      eventHandlers:
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
+        - event: SwapFeePercentageChanged(uint256)
+          handler: handleSwapFeePercentageChange
+        - event: PriceRateProviderSet(indexed address,indexed address,uint256)
+          handler: handlePriceRateProviderSet
+        - event: PriceRateCacheUpdated(indexed address,uint256)
+          handler: handlePriceRateCacheUpdated
+  - kind: ethereum/contract
+    name: LinearPool
+    network: {{network}}
+    source:
+      abi: LinearPool
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      file: ./src/mappings/poolController.ts
+      entities:
+        - Pool
+        - PoolShare
+        - Swap
+        - PoolToken
+        - PriceRateProvider
+      abis:
+        - name: WeightedPool # Necessary for Transfer handler
+          file: ./abis/WeightedPool.json
+        - name: LinearPool
+          file: ./abis/LinearPool.json
         - name: BalancerPoolToken
           file: ./abis/BalancerPoolToken.json
       eventHandlers:

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -122,6 +122,8 @@ dataSources:
           file: ./abis/ERC20.json
         - name: StablePoolFactory
           file: ./abis/StablePoolFactory.json
+        - name: WeightedPool
+          file: ./abis/WeightedPool.json
         - name: StablePool
           file: ./abis/StablePool.json
       eventHandlers:
@@ -151,8 +153,8 @@ dataSources:
           file: ./abis/ERC20.json
         - name: MetaStablePoolFactory
           file: ./abis/MetaStablePoolFactory.json
-        - name: StablePool
-          file: ./abis/StablePool.json
+        - name: WeightedPool
+          file: ./abis/WeightedPool.json
         - name: MetaStablePool
           file: ./abis/MetaStablePool.json
       eventHandlers:

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -121,6 +121,8 @@ dataSources:
           file: ./abis/ERC20.json
         - name: StablePoolFactory
           file: ./abis/StablePoolFactory.json
+        - name: WeightedPool
+          file: ./abis/WeightedPool.json
         - name: StablePool
           file: ./abis/StablePool.json
       eventHandlers:
@@ -148,8 +150,8 @@ dataSources:
           file: ./abis/ERC20.json
         - name: MetaStablePoolFactory
           file: ./abis/MetaStablePoolFactory.json
-        - name: StablePool
-          file: ./abis/StablePool.json
+        - name: WeightedPool
+          file: ./abis/WeightedPool.json
         - name: MetaStablePool
           file: ./abis/MetaStablePool.json
       eventHandlers:


### PR DESCRIPTION
This PR adds a skeleton for supporting Linear pools in the subgraph so that the SOR can use them. It still requires final ABIs + deployment info plus there's some interface decisions to be finalised.

Things to do before merging
- [ ] consider whether `lowerTarget` and `upperTarget` should live on the `Pool` entity or on the `PoolToken`. It should probably be renamed in any case.
- [ ] add ABIs for `LinearPool` and `LinearPoolFactory`
- [ ] add addresses + start blocks to `networks.ts`
- [ ] run `yarn codegen` and commit newly generated manifest files.
