### PR TITLE
Hotfix: prevent division by zero when calculating poolShareValue

### DIFF
--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -82,7 +82,7 @@ export function updatePoolLiquidity(poolId: string, block: BigInt, pricingAsset:
   phl.block = block;
   phl.poolTotalShares = pool.totalShares;
   phl.poolLiquidity = poolValue;
-  phl.poolShareValue = poolValue.div(pool.totalShares);
+  phl.poolShareValue = pool.totalShares.gt(ZERO_BD) ? poolValue.div(pool.totalShares) : ZERO_BD;
   phl.save();
 
   // Update pool stats


### PR DESCRIPTION
[This transaction](https://kovan.etherscan.io/tx/0xe13213200161f6ab10c87d70c7e61f7dcf0cc570feca852e6edb09bc0002dff6) in which an LBP is deployed and funded in the same transaction results in a division by zero on this line.

It seems odd that this would be an issue as the logs are all occurring in the same order as the case where deployment + funding happens in two transactions so it should be handled in the same way but it is. This root cause needs a bit more investigation but in the meantime we can add a check to make sure that `pool.totalShares` is greater than zero. 