### PR TITLE
Require a minimum amount of pool liquidity for it to be used in setting token prices

### DIFF
--- a/src/mappings/helpers/constants.ts
+++ b/src/mappings/helpers/constants.ts
@@ -3,6 +3,7 @@ import { BigDecimal, BigInt, Address, dataSource } from '@graphprotocol/graph-ts
 export let ZERO = BigInt.fromI32(0);
 export let ZERO_BD = BigDecimal.fromString('0');
 export let ONE_BD = BigDecimal.fromString('1');
+export let MIN_POOL_VIABLE_LIQUIDITY = BigDecimal.fromString('1');
 export const SWAP_IN = 0;
 export const SWAP_OUT = 1;
 

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -25,7 +25,7 @@ import {
 } from './helpers/misc';
 import { updatePoolWeights } from './helpers/weighted';
 import { isUSDStable, isPricingAsset, updatePoolLiquidity, valueInUSD } from './pricing';
-import { SWAP_IN, SWAP_OUT, ZERO, ZERO_BD, ONE_BD } from './helpers/constants';
+import { SWAP_IN, SWAP_OUT, ZERO, ZERO_BD, ONE_BD, MIN_POOL_VIABLE_LIQUIDITY } from './helpers/constants';
 import { isStableLikePool, isVariableWeightPool } from './helpers/pools';
 import { updateAmpFactor } from './helpers/stable';
 
@@ -399,7 +399,7 @@ export function handleSwapEvent(event: SwapEvent): void {
   let block = event.block.number;
   let tokenInWeight = poolTokenIn.weight;
   let tokenOutWeight = poolTokenOut.weight;
-  if (isPricingAsset(tokenInAddress)) {
+  if (isPricingAsset(tokenInAddress) && pool.totalLiquidity.gt(MIN_POOL_VIABLE_LIQUIDITY)) {
     let tokenPriceId = getTokenPriceId(poolId.toHex(), tokenOutAddress, tokenInAddress, block);
     let tokenPrice = new TokenPrice(tokenPriceId);
     //tokenPrice.poolTokenId = getPoolTokenId(poolId, tokenOutAddress);
@@ -422,7 +422,7 @@ export function handleSwapEvent(event: SwapEvent): void {
     tokenPrice.save();
     updatePoolLiquidity(poolId.toHex(), block, tokenInAddress, blockTimestamp);
   }
-  if (isPricingAsset(tokenOutAddress)) {
+  if (isPricingAsset(tokenOutAddress) && pool.totalLiquidity.gt(MIN_POOL_VIABLE_LIQUIDITY)) {
     let tokenPriceId = getTokenPriceId(poolId.toHex(), tokenInAddress, tokenOutAddress, block);
     let tokenPrice = new TokenPrice(tokenPriceId);
     //tokenPrice.poolTokenId = getPoolTokenId(poolId, tokenInAddress);


### PR DESCRIPTION
Big thanks to @mendesfabio for helping us track this one down.

After applying the initial set of fixes, we still had some spikes in our TVL.
![Screenshot 2021-11-09 at 17 17 11](https://user-images.githubusercontent.com/91405705/141082125-654f33f7-9d3d-4d5f-bfdf-4e8529d6f6d2.png)

We tracked the spike down to the following pool and swap:
![Screenshot 2021-11-10 at 10 12 18](https://user-images.githubusercontent.com/91405705/141084379-49bbe2ea-25fa-4264-8f38-9b1eb27227cd.png)

https://us-lb.beets-ftm-node.com/subgraphs/name/beethovenx-canary/graphql?query=%7B%0A%20%20balancers(first%3A%20100%2C%20block%3A%20%7Bnumber%3A%2021291092%7D)%20%7B%0A%20%20%20%20totalLiquidity%0A%20%20%7D%0A%20%20pool(id%3A%20%220xab4bd6b4c479df78e2953de1c877bfd634dfbb87000200000000000000000060%22%2C%20block%3A%20%7Bnumber%3A%2021290045%7D)%20%7B%0A%20%20%20%20id%0A%20%20%20%20totalLiquidity%0A%20%20%20%20name%0A%20%20%20%20tokens%20%7B%0A%20%20%20%20%20%20address%0A%20%20%20%20%20%20symbol%0A%20%20%20%20%20%20balance%0A%20%20%20%20%20%20weight%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20latestPrice(id%3A%20%220xd8321aa83fb0a4ecd6348d4577431310a6e0814d-0xf24bcf4d1e507740041c9cfd2dddb29585adce1e%22%2C%20block%3A%20%7Bnumber%3A%2021290046%7D)%20%7B%0A%20%20%20%20id%0A%20%20%20%20asset%0A%20%20%20%20priceUSD%0A%20%20%20%20pricingAsset%0A%20%20%20%20price%0A%20%20%7D%0A%20%20swap(id%3A%20%220xd2b842e82f5bc2628190dfe885e7c89fec502d9aa95b430bc88ca58bc878a2888%22)%20%7B%0A%20%20%20%20tokenInSym%0A%20%20%20%20tokenOutSym%0A%20%20%20%20tokenAmountIn%0A%20%20%20%20tokenAmountOut%0A%20%20%20%20tx%0A%20%20%20%20poolId%20%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%7D%0A%20%20%20%20timestamp%0A%20%20%20%20userAddress%20%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A

The token price math caused by the above swap:
`newInAmount = 0.000035241645993768 + 0.000000000000042022 = 0.000035241646036`
`newOutAmount = 0.000000000000136465 - 0.000000000000028666 = 0.000000000000108`
`tokenInWeight = 0.8`
`tokenOutWeight = 0.2`
`tokenOutPrice = 0.000035241646036 / 0.8 / (0.000000000000108 / 0.2) = 81577884.342592592592593 BEETS`

The issue here is that a swap passes through a pool with only dust, causing it to massively inflate the price of one asset. The actual price of the asset shown above is approx $1.20, but after the swap is processed, the price is $62 million per token.

Pools with very little liquidity can be manipulated easily, causing asset prices to shift very far away from their actual price. We'd propose setting a `MIN_POOL_VIABLE_LIQUIDITY` dollar value that is the minimum total liquidity required for a pool to be used in determining token prices. We set the price to $1, but this could easily be higher. Rerunning our subgraph with the proposed solution removed any remaining TVL spikes we've seen.
