### PR TITLE
Force resync

### DIFF
--- a/subgraph.polygon.yaml
+++ b/subgraph.polygon.yaml
@@ -477,3 +477,4 @@ templates:
           handler: handlePriceRateProviderSet
         - event: PriceRateCacheUpdated(indexed address,uint256)
           handler: handlePriceRateCacheUpdated
+


### PR DESCRIPTION
Last week we noticed an issue with the Polygon Subgraph. After talking to Edge&Node guys, they realized the JSON RPC provider was missing some transactions. They fixed the bug and now we need to redeploy. This PR only adds a newline to the manifest file to force it to resync.