### PR TITLE
fix: boosted bpt price

### DIFF
--- a/src/mappings/pricing.ts
+++ b/src/mappings/pricing.ts
@@ -2,7 +2,7 @@ import { Address, Bytes, BigInt, BigDecimal } from '@graphprotocol/graph-ts';
 import { Pool, TokenPrice, Balancer, PoolHistoricalLiquidity, LatestPrice } from '../types/schema';
 import { ZERO_BD, PRICING_ASSETS, USD_STABLE_ASSETS, ONE_BD } from './helpers/constants';
 import { hasVirtualSupply } from './helpers/pools';
-import { getBalancerSnapshot, getToken, getTokenPriceId, loadPoolToken } from './helpers/misc';
+import { createPoolSnapshot, getBalancerSnapshot, getToken, getTokenPriceId, loadPoolToken } from './helpers/misc';
 
 export function isPricingAsset(asset: Address): boolean {
   for (let i: i32 = 0; i < PRICING_ASSETS.length; i++) {
@@ -46,7 +46,7 @@ export function updatePoolLiquidity(poolId: string, block: BigInt, pricingAsset:
     // note that we can only meaningfully report liquidity once assets are traded with
     // the pricing asset
     if (tokenPrice) {
-      //value in terms of priceableAsset
+      // value in terms of priceableAsset
       price = tokenPrice.price;
 
       // Possibly update latest price
@@ -63,11 +63,31 @@ export function updatePoolLiquidity(poolId: string, block: BigInt, pricingAsset:
       let token = getToken(tokenAddress);
       token.latestPrice = latestPrice.id;
       token.save();
+    } else {
+      // try to estimate token price in terms of pricing asset
+      let pricingAssetInUSD = valueInUSD(ONE_BD, pricingAsset);
+      let currentTokenInUSD = valueInUSD(ONE_BD, tokenAddress);
+
+      if (pricingAssetInUSD.equals(ZERO_BD) || currentTokenInUSD.equals(ZERO_BD)) {
+        continue;
+      }
+
+      price = currentTokenInUSD.div(pricingAssetInUSD);
+
+      let tokenPrice = new TokenPrice(tokenPriceId);
+      tokenPrice.asset = tokenAddress;
+      tokenPrice.pricingAsset = pricingAsset;
+      tokenPrice.price = price;
+      tokenPrice.block = block;
+      tokenPrice.poolId = poolId;
+      tokenPrice.save();
     }
+
     // Exclude virtual supply from pool value
     if (hasVirtualSupply(pool) && pool.address == tokenAddress) {
       continue;
     }
+
     if (price) {
       let poolTokenValue = price.times(poolTokenQuantity);
       poolValue = poolValue.plus(poolTokenValue);
@@ -98,6 +118,8 @@ export function updatePoolLiquidity(poolId: string, block: BigInt, pricingAsset:
   // Update pool stats
   pool.totalLiquidity = newPoolLiquidity;
   pool.save();
+
+  createPoolSnapshot(pool, timestamp);
 
   // Update global stats
   let vault = Balancer.load('2') as Balancer;

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -10,7 +10,6 @@ import {
   tokenToDecimal,
   getTokenPriceId,
   scaleDown,
-  createPoolSnapshot,
   createUserEntity,
   getTokenDecimals,
   loadPoolToken,
@@ -159,8 +158,6 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
       pool.save();
     }
   }
-
-  createPoolSnapshot(pool, blockTimestamp);
 }
 
 function handlePoolExited(event: PoolBalanceChanged): void {
@@ -237,8 +234,6 @@ function handlePoolExited(event: PoolBalanceChanged): void {
       }
     }
   }
-
-  createPoolSnapshot(pool, blockTimestamp);
 }
 
 /************************************

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -442,6 +442,4 @@ export function handleSwapEvent(event: SwapEvent): void {
     tokenPrice.save();
     updatePoolLiquidity(poolId.toHex(), block, tokenOutAddress, blockTimestamp);
   }
-
-  createPoolSnapshot(pool, blockTimestamp);
 }


### PR DESCRIPTION
Last week we found two problems with Linear and StablePhantom BPT prices.

1. In `PoolSnapshot` of Boosted BPT we had this price peak. This happened because `createPoolSnapshot` function was in the wrong scope and used out of date information to update the snapshot. I moved the function to inside the `updatePoolLiquidity`.

![newplot (19)](https://user-images.githubusercontent.com/43360747/148766138-277cd3a4-54d1-4b0c-9cef-f42bd098ffdb.png)

2. At the beginning, the pool didn't have all Linear BPTs priced in terms of the other Linear BPTs. Because of that, the Boosted pool could only account to a portion of its liquidity, and the BPT price resultant was less than it should be. To fix this one, I added an else statement to `updatePoolLiquidity` function to estimate the token price based on the USD value of each asset - only if we have both priced.

![newplot (18)](https://user-images.githubusercontent.com/43360747/148766144-bbed200b-392d-4e6c-8d82-84766307772a.png)