### PR TITLE
redeploy dev

### DIFF
--- a/.github/workflows/graph-beta.yml
+++ b/.github/workflows/graph-beta.yml
@@ -47,27 +47,27 @@ jobs:
           graph_subgraph_name: "balancer-kovan-v2-beta"
           graph_account: "balancer-labs"
           graph_config_file: "subgraph.kovan.yaml"
-  #deploy-polygon-beta:
-    #runs-on: ubuntu-latest
-    #environment: graph
-    #steps:
-      #- uses: actions/checkout@v2
-      #- name: Install node
-        #uses: actions/setup-node@v1
-        #with:
-          #node-version: 14
-      #- name: Install
-        #run: yarn --frozen-lockfile
-      #- name: Codegen
-        #run: yarn codegen
-      #- name: Build
-        #run: yarn build
-      #- uses: gtaschuk/graph-deploy@v0.1.5
-        #with:
-          #graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-          #graph_subgraph_name: "balancer-polygon-v2-beta"
-          #graph_account: "balancer-labs"
-          #graph_config_file: "subgraph.polygonGrafted.yaml"
+  deploy-polygon-beta:
+    runs-on: ubuntu-latest
+    environment: graph
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - name: Install
+        run: yarn --frozen-lockfile
+      - name: Codegen
+        run: yarn codegen
+      - name: Build
+        run: yarn build
+      - uses: gtaschuk/graph-deploy@v0.1.5
+        with:
+          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+          graph_subgraph_name: "balancer-polygon-v2-beta"
+          graph_account: "balancer-labs"
+          graph_config_file: "subgraph.polygon.yaml"
   deploy-arbitrum-beta:
     runs-on: ubuntu-latest
     environment: graph

--- a/src/mappings/helpers/weighted.ts
+++ b/src/mappings/helpers/weighted.ts
@@ -16,22 +16,25 @@ export function updatePoolWeights(poolId: string): void {
   let weightsCall = poolContract.try_getNormalizedWeights();
   if (!weightsCall.reverted) {
     let weights = weightsCall.value;
-    let totalWeight = ZERO_BD;
 
-    for (let i: i32 = 0; i < tokensList.length; i++) {
-      let tokenAddress = changetype<Address>(tokensList[i]);
-      let weight = weights[i];
+    if (weights.length == tokensList.length) {
+      let totalWeight = ZERO_BD;
 
-      let poolToken = loadPoolToken(poolId, tokenAddress);
-      if (poolToken != null) {
-        poolToken.weight = scaleDown(weight, 18);
-        poolToken.save();
+      for (let i = 0; i < tokensList.length; i++) {
+        let tokenAddress = changetype<Address>(tokensList[i]);
+        let weight = weights[i];
+
+        let poolToken = loadPoolToken(poolId, tokenAddress);
+        if (poolToken != null) {
+          poolToken.weight = scaleDown(weight, 18);
+          poolToken.save();
+        }
+
+        totalWeight = totalWeight.plus(scaleDown(weight, 18));
       }
 
-      totalWeight = totalWeight.plus(scaleDown(weight, 18));
+      pool.totalWeight = totalWeight;
     }
-
-    pool.totalWeight = totalWeight;
   }
 
   pool.save();


### PR DESCRIPTION
We had an issue in `/helpers/weight.ts` due to an instability of TheGraph's RPC provider. Instead of reverting the call to get tokens weights (line 16), the provider returned an empty list, leading to an `index out of range` error. To fix that, we're checking if both lists have the same length before getting their elements.

Also, this PR restore the Polygon Beta deploy via GitHub Actions. We want to do a full sync this week to get the same schema and setup across all networks.