### PR TITLE
fix timestamps types

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -121,8 +121,8 @@ type GradualWeightUpdate @entity {
   id: ID!
   poolId: Pool!
   scheduledTimestamp: Int!
-  startTimestamp: Int!
-  endTimestamp: Int!
+  startTimestamp: BigInt!
+  endTimestamp: BigInt!
   startWeights: [BigInt!]!
   endWeights: [BigInt!]!
 }
@@ -131,8 +131,8 @@ type AmpUpdate @entity {
   id: ID!
   poolId: Pool!
   scheduledTimestamp: Int!
-  startTimestamp: Int!
-  endTimestamp: Int!
+  startTimestamp: BigInt!
+  endTimestamp: BigInt!
   startAmp: BigInt!
   endAmp: BigInt!
 }

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -61,8 +61,8 @@ export function handleGradualWeightUpdateScheduled(event: GradualWeightUpdateSch
   let weightUpdate = new GradualWeightUpdate(id);
   weightUpdate.poolId = poolId.toHexString();
   weightUpdate.scheduledTimestamp = event.block.timestamp.toI32();
-  weightUpdate.startTimestamp = event.params.startTime.toI32();
-  weightUpdate.endTimestamp = event.params.endTime.toI32();
+  weightUpdate.startTimestamp = event.params.startTime;
+  weightUpdate.endTimestamp = event.params.endTime;
   weightUpdate.startWeights = event.params.startWeights;
   weightUpdate.endWeights = event.params.endWeights;
   weightUpdate.save();
@@ -84,8 +84,8 @@ export function handleAmpUpdateStarted(event: AmpUpdateStarted): void {
   let ampUpdate = new AmpUpdate(id);
   ampUpdate.poolId = poolId.toHexString();
   ampUpdate.scheduledTimestamp = event.block.timestamp.toI32();
-  ampUpdate.startTimestamp = event.params.startTime.toI32();
-  ampUpdate.endTimestamp = event.params.endTime.toI32();
+  ampUpdate.startTimestamp = event.params.startTime;
+  ampUpdate.endTimestamp = event.params.endTime;
   ampUpdate.startAmp = event.params.startValue;
   ampUpdate.endAmp = event.params.endValue;
   ampUpdate.save();
@@ -103,8 +103,8 @@ export function handleAmpUpdateStopped(event: AmpUpdateStopped): void {
   let ampUpdate = new AmpUpdate(id);
   ampUpdate.poolId = poolId;
   ampUpdate.scheduledTimestamp = event.block.timestamp.toI32();
-  ampUpdate.startTimestamp = event.block.timestamp.toI32();
-  ampUpdate.endTimestamp = event.block.timestamp.toI32();
+  ampUpdate.startTimestamp = event.block.timestamp;
+  ampUpdate.endTimestamp = event.block.timestamp;
   ampUpdate.startAmp = event.params.currentValue;
   ampUpdate.endAmp = event.params.currentValue;
   ampUpdate.save();


### PR DESCRIPTION
We decided to change `startTimestamp` and `endTimestamp` to `BigInt` because they're fields informed by the users and might be manipulated to broke the Subgraph. In this [transaction](https://kovan.etherscan.io/tx/0x281579087b2780032f6b3190adb8bb0b5c452110c0e7487dcba0254484a69b51#eventlog), for instance, the user inputs timestamps fields in milliseconds - which's larger than I32 - and that led to an overflow error.