### PR TITLE
fix oracle enabled handler

### DIFF
--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -1,6 +1,6 @@
 import { BigInt, log } from '@graphprotocol/graph-ts';
 import { Transfer } from '../types/templates/WeightedPool/BalancerPoolToken';
-import { WeightedPool2Tokens, OracleEnabledChanged } from '../types/templates/WeightedPool2Tokens/WeightedPool2Tokens';
+import { OracleEnabledChanged } from '../types/templates/WeightedPool2Tokens/WeightedPool2Tokens';
 import { WeightedPool, SwapFeePercentageChanged } from '../types/templates/WeightedPool/WeightedPool';
 import {
   GradualWeightUpdateScheduled,
@@ -34,7 +34,7 @@ import { updateAmpFactor } from './helpers/stable';
 
 export function handleOracleEnabledChanged(event: OracleEnabledChanged): void {
   let poolAddress = event.address;
-  let poolContract = WeightedPool2Tokens.bind(poolAddress);
+  let poolContract = WeightedPool.bind(poolAddress);
 
   let poolIdCall = poolContract.try_getPoolId();
   let poolId = poolIdCall.value;


### PR DESCRIPTION
Subgraph failed to sync because `WeightedPool2Tokens` ABI was missing. Since we've already declared the `WeightedPool` ABI to all pools (and used it to bind contracts and get the poolId), I only did the same for this handler.

> Could not find ABI for contract "WeightedPool2Tokens", try adding it to the 'abis' section of the subgraph manifest wasm backtrace: 0: 0x2496 - <unknown>!~lib/@graphprotocol/graph-ts/chain/ethereum/ethereum.SmartContract#tryCall 1: 0x2a91 - <unknown>!src/mappings/poolController/handleOracleEnabledChanged

