### PR TITLE
add swap value threshold to pricing

### DIFF
--- a/src/mappings/helpers/constants.ts
+++ b/src/mappings/helpers/constants.ts
@@ -9,6 +9,7 @@ export const SWAP_OUT = 1;
 export let ZERO_ADDRESS = Address.fromString('0x0000000000000000000000000000000000000000');
 
 export let MIN_POOL_LIQUIDITY = BigDecimal.fromString('2000');
+export let MIN_SWAP_VALUE_USD = BigDecimal.fromString('1');
 
 export class AddressByNetwork {
   public mainnet: string;

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -30,7 +30,15 @@ import {
   getPreferentialPricingAsset,
   updateLatestPrice,
 } from './pricing';
-import { MIN_POOL_LIQUIDITY, SWAP_IN, SWAP_OUT, ZERO, ZERO_ADDRESS, ZERO_BD } from './helpers/constants';
+import {
+  MIN_POOL_LIQUIDITY,
+  MIN_SWAP_VALUE_USD,
+  SWAP_IN,
+  SWAP_OUT,
+  ZERO,
+  ZERO_ADDRESS,
+  ZERO_BD,
+} from './helpers/constants';
 import { hasVirtualSupply, isVariableWeightPool, isStableLikePool } from './helpers/pools';
 import { updateAmpFactor } from './helpers/stable';
 
@@ -435,7 +443,11 @@ export function handleSwapEvent(event: SwapEvent): void {
   let block = event.block.number;
   let tokenInWeight = poolTokenIn.weight;
   let tokenOutWeight = poolTokenOut.weight;
-  if (isPricingAsset(tokenInAddress) && pool.totalLiquidity.gt(MIN_POOL_LIQUIDITY)) {
+  if (
+    isPricingAsset(tokenInAddress) &&
+    pool.totalLiquidity.gt(MIN_POOL_LIQUIDITY) &&
+    swap.valueUSD.gt(MIN_SWAP_VALUE_USD)
+  ) {
     let tokenPriceId = getTokenPriceId(poolId.toHex(), tokenOutAddress, tokenInAddress, block);
     let tokenPrice = new TokenPrice(tokenPriceId);
     //tokenPrice.poolTokenId = getPoolTokenId(poolId, tokenOutAddress);
@@ -459,7 +471,11 @@ export function handleSwapEvent(event: SwapEvent): void {
 
     updateLatestPrice(tokenPrice);
   }
-  if (isPricingAsset(tokenOutAddress) && pool.totalLiquidity.gt(MIN_POOL_LIQUIDITY)) {
+  if (
+    isPricingAsset(tokenOutAddress) &&
+    pool.totalLiquidity.gt(MIN_POOL_LIQUIDITY) &&
+    swap.valueUSD.gt(MIN_SWAP_VALUE_USD)
+  ) {
     let tokenPriceId = getTokenPriceId(poolId.toHex(), tokenInAddress, tokenOutAddress, block);
     let tokenPrice = new TokenPrice(tokenPriceId);
     //tokenPrice.poolTokenId = getPoolTokenId(poolId, tokenInAddress);


### PR DESCRIPTION
Add a check to price assets against each other only when the value USD is more significant than $1. This change prevents small trades - mainly in Stable-like pools - from registering anomaly prices.