### PR TITLE
Capture holdersCount and swapsCount in PoolSnapshot entity

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -233,6 +233,8 @@ type PoolSnapshot @entity {
   swapVolume: BigDecimal!
   swapFees: BigDecimal!
   liquidity: BigDecimal!
+  swapsCount: BigInt!
+  holdersCount: BigInt!
   timestamp: Int!
 }
 

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -190,6 +190,8 @@ export function createPoolSnapshot(pool: Pool, timestamp: i32): void {
   snapshot.swapVolume = pool.totalSwapVolume;
   snapshot.swapFees = pool.totalSwapFee;
   snapshot.liquidity = pool.totalLiquidity;
+  snapshot.swapsCount = pool.swapsCount;
+  snapshot.holdersCount = pool.holdersCount;
   snapshot.timestamp = dayTimestamp;
   snapshot.save();
 }


### PR DESCRIPTION
This tiny PR adds `holdersCount` and `swapsCount` to the `PoolSnapshot` entity. We find it useful to have this data also captured for historical graphs.