### PR TITLE
Remove weightedv2 from polygon

### DIFF
--- a/networks.yaml
+++ b/networks.yaml
@@ -101,9 +101,6 @@ polygon:
   WeightedPoolFactory:
     address: "0x8E9aa87E45e92bad84D5F8DD1bff34Fb92637dE9"
     startBlock: 15832998
-  WeightedPoolV2Factory:
-    address: "0x0e39C3D9b2ec765eFd9c5c70BB290B1fCD8536E3"
-    startBlock: 32850162
   WeightedPool2TokenFactory:
     address: "0xA5bf2ddF098bb0Ef6d120C98217dD6B141c74EE0"
     startBlock: 15869090
@@ -161,9 +158,6 @@ polygonGrafted:
   WeightedPoolFactory:
     address: "0x8E9aa87E45e92bad84D5F8DD1bff34Fb92637dE9"
     startBlock: 15832998
-  WeightedPoolV2Factory:
-    address: "0x0e39C3D9b2ec765eFd9c5c70BB290B1fCD8536E3"
-    startBlock: 32850162
   WeightedPool2TokenFactory:
     address: "0xA5bf2ddF098bb0Ef6d120C98217dD6B141c74EE0"
     startBlock: 15869090

--- a/networks.yaml
+++ b/networks.yaml
@@ -153,8 +153,8 @@ polygon:
 polygonGrafted:
   network: matic
   graft:
-    block: 32850161
-    base: QmbxbnHYSSpW5FCo6rQwUUSG719nEmwHWqZZTJxAd5k6wb
+    block: 32001447
+    base: QmeYB9NoVzq6orxCZhQrFPBrFnuujrXAdVzCDiD2U2JzrY
   Vault:
     address: "0xBA12222222228d8Ba445958a75a0704d566BF2C8"
     startBlock: 15832990


### PR DESCRIPTION
An issue with the subgraph is preventing the sync on Polygon to complete. 
With this PR I expect we'll be able to effectively cancel the pending sync of QmewrUmY3tooHpXHUbMK7vXAEPdkRjf7GuztXUvpHBDYpy on Polygon and then we can merge `dev` to `master` so that the production subgraphs support all pools, except Weighted V2 on Polygon. 