### PR TITLE
Fix join/exit valueUSD and token.totalBalanceUSD

### DIFF
--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -144,7 +144,7 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
 
     let token = getToken(tokenAddress);
     token.totalBalanceNotional = token.totalBalanceNotional.plus(tokenAmountIn);
-    token.totalBalanceUSD = token.totalBalanceUSD.plus(tokenAmountInUSD);
+    token.totalBalanceUSD = valueInUSD(token.totalBalanceNotional, tokenAddress);
     token.save();
 
     let tokenSnapshot = getTokenSnapshot(tokenAddress, event);
@@ -249,7 +249,7 @@ function handlePoolExited(event: PoolBalanceChanged): void {
 
     let token = getToken(tokenAddress);
     token.totalBalanceNotional = token.totalBalanceNotional.minus(tokenAmountOut);
-    token.totalBalanceUSD = token.totalBalanceUSD.minus(tokenAmountOutUSD);
+    token.totalBalanceUSD = valueInUSD(token.totalBalanceNotional, tokenAddress);
     token.save();
 
     let tokenSnapshot = getTokenSnapshot(tokenAddress, event);

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -238,12 +238,6 @@ function handlePoolExited(event: PoolBalanceChanged): void {
     let amountOut = amounts[i].minus(protocolFeeAmounts[i]).neg();
     let tokenAmountOut = tokenToDecimal(amountOut, poolToken.decimals);
     let newBalance = poolToken.balance.minus(tokenAmountOut);
-
-    let tokenExitAmount = amounts[i];
-    let scaledTokenExitAmount = tokenToDecimal(tokenExitAmount, poolToken.decimals);
-    let tokenExitAmountInUSD = valueInUSD(scaledTokenExitAmount, tokenAddress);
-    valueUSD = valueUSD.plus(tokenExitAmountInUSD);
-
     poolToken.balance = newBalance;
     poolToken.save();
 

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -140,7 +140,6 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
     let amountIn = amounts[i].minus(protocolFeeAmounts[i]);
     let tokenAmountIn = tokenToDecimal(amountIn, poolToken.decimals);
     let newAmount = poolToken.balance.plus(tokenAmountIn);
-    let tokenAmountInUSD = valueInUSD(tokenAmountIn, tokenAddress);
 
     let token = getToken(tokenAddress);
     token.totalBalanceNotional = token.totalBalanceNotional.plus(tokenAmountIn);
@@ -237,7 +236,6 @@ function handlePoolExited(event: PoolBalanceChanged): void {
     let amountOut = amounts[i].minus(protocolFeeAmounts[i]).neg();
     let tokenAmountOut = tokenToDecimal(amountOut, poolToken.decimals);
     let newAmount = poolToken.balance.minus(tokenAmountOut);
-    let tokenAmountOutUSD = valueInUSD(tokenAmountOut, tokenAddress);
 
     let tokenExitAmount = amounts[i];
     let scaledTokenExitAmount = tokenToDecimal(tokenExitAmount, poolToken.decimals);

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -139,7 +139,7 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
     }
     let amountIn = amounts[i].minus(protocolFeeAmounts[i]);
     let tokenAmountIn = tokenToDecimal(amountIn, poolToken.decimals);
-    let newAmount = poolToken.balance.plus(tokenAmountIn);
+    let newBalance = poolToken.balance.plus(tokenAmountIn);
 
     let token = getToken(tokenAddress);
     token.totalBalanceNotional = token.totalBalanceNotional.plus(tokenAmountIn);
@@ -151,7 +151,7 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
     tokenSnapshot.totalBalanceUSD = token.totalBalanceUSD;
     tokenSnapshot.save();
 
-    poolToken.balance = newAmount;
+    poolToken.balance = newBalance;
     poolToken.save();
   }
 
@@ -235,14 +235,14 @@ function handlePoolExited(event: PoolBalanceChanged): void {
     }
     let amountOut = amounts[i].minus(protocolFeeAmounts[i]).neg();
     let tokenAmountOut = tokenToDecimal(amountOut, poolToken.decimals);
-    let newAmount = poolToken.balance.minus(tokenAmountOut);
+    let newBalance = poolToken.balance.minus(tokenAmountOut);
 
     let tokenExitAmount = amounts[i];
     let scaledTokenExitAmount = tokenToDecimal(tokenExitAmount, poolToken.decimals);
     let tokenExitAmountInUSD = valueInUSD(scaledTokenExitAmount, tokenAddress);
     valueUSD = valueUSD.plus(tokenExitAmountInUSD);
 
-    poolToken.balance = newAmount;
+    poolToken.balance = newBalance;
     poolToken.save();
 
     let token = getToken(tokenAddress);

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -140,6 +140,8 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
     let amountIn = amounts[i].minus(protocolFeeAmounts[i]);
     let tokenAmountIn = tokenToDecimal(amountIn, poolToken.decimals);
     let newBalance = poolToken.balance.plus(tokenAmountIn);
+    poolToken.balance = newBalance;
+    poolToken.save();
 
     let token = getToken(tokenAddress);
     const tokenTotalBalanceNotional = token.totalBalanceNotional.minus(tokenAmountIn);
@@ -152,9 +154,6 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
     tokenSnapshot.totalBalanceNotional = tokenTotalBalanceNotional;
     tokenSnapshot.totalBalanceUSD = tokenTotalBalanceUSD;
     tokenSnapshot.save();
-
-    poolToken.balance = newBalance;
-    poolToken.save();
   }
 
   for (let i: i32 = 0; i < tokenAddresses.length; i++) {

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -142,7 +142,6 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
     let newAmount = poolToken.balance.plus(tokenAmountIn);
     let tokenAmountInUSD = valueInUSD(tokenAmountIn, tokenAddress);
 
-
     let token = getToken(tokenAddress);
     token.totalBalanceNotional = token.totalBalanceNotional.plus(tokenAmountIn);
     token.totalBalanceUSD = token.totalBalanceUSD.plus(tokenAmountInUSD);

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -142,13 +142,15 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
     let newBalance = poolToken.balance.plus(tokenAmountIn);
 
     let token = getToken(tokenAddress);
-    token.totalBalanceNotional = token.totalBalanceNotional.plus(tokenAmountIn);
-    token.totalBalanceUSD = valueInUSD(token.totalBalanceNotional, tokenAddress);
+    const tokenTotalBalanceNotional = token.totalBalanceNotional.minus(tokenAmountIn);
+    const tokenTotalBalanceUSD = valueInUSD(tokenTotalBalanceNotional, tokenAddress);
+    token.totalBalanceNotional = tokenTotalBalanceNotional;
+    token.totalBalanceUSD = tokenTotalBalanceUSD;
     token.save();
 
     let tokenSnapshot = getTokenSnapshot(tokenAddress, event);
-    tokenSnapshot.totalBalanceNotional = token.totalBalanceNotional;
-    tokenSnapshot.totalBalanceUSD = token.totalBalanceUSD;
+    tokenSnapshot.totalBalanceNotional = tokenTotalBalanceNotional;
+    tokenSnapshot.totalBalanceUSD = tokenTotalBalanceUSD;
     tokenSnapshot.save();
 
     poolToken.balance = newBalance;
@@ -246,13 +248,15 @@ function handlePoolExited(event: PoolBalanceChanged): void {
     poolToken.save();
 
     let token = getToken(tokenAddress);
-    token.totalBalanceNotional = token.totalBalanceNotional.minus(tokenAmountOut);
-    token.totalBalanceUSD = valueInUSD(token.totalBalanceNotional, tokenAddress);
+    const tokenTotalBalanceNotional = token.totalBalanceNotional.minus(tokenAmountOut);
+    const tokenTotalBalanceUSD = valueInUSD(tokenTotalBalanceNotional, tokenAddress);
+    token.totalBalanceNotional = tokenTotalBalanceNotional;
+    token.totalBalanceUSD = tokenTotalBalanceUSD;
     token.save();
 
     let tokenSnapshot = getTokenSnapshot(tokenAddress, event);
-    tokenSnapshot.totalBalanceNotional = token.totalBalanceNotional;
-    tokenSnapshot.totalBalanceUSD = token.totalBalanceUSD;
+    tokenSnapshot.totalBalanceNotional = tokenTotalBalanceNotional;
+    tokenSnapshot.totalBalanceUSD = tokenTotalBalanceUSD;
     tokenSnapshot.save();
   }
 


### PR DESCRIPTION
Implementation from #260 was using the amount by which the pool balance changed, which could be negative on joins due to protocol fees being collected.

Also, token.totalBalanceUSD was not being updated based on notional balance and most recent known price of the token