### PR TITLE
fix: linear pools don't accrue fees

### DIFF
--- a/src/mappings/helpers/pools.ts
+++ b/src/mappings/helpers/pools.ts
@@ -15,7 +15,7 @@ export namespace PoolType {
   export const ComposableStable = 'ComposableStable';
   export const AaveLinear = 'AaveLinear';
   export const ERC4626Linear = 'ERC4626Linear';
-  export const Linear = 'AaveLinear';
+  // export const Linear = 'AaveLinear';
   export const Gyro2 = 'Gyro2';
   export const Gyro3 = 'Gyro3';
   export const GyroCEMM = 'GyroCEMM';
@@ -31,6 +31,13 @@ export function hasVirtualSupply(pool: Pool): boolean {
     pool.poolType == PoolType.ERC4626Linear ||
     pool.poolType == PoolType.StablePhantom ||
     pool.poolType == PoolType.ComposableStable
+  );
+}
+
+export function isLinearPool(pool: Pool): boolean {
+  return (
+    pool.poolType == PoolType.AaveLinear ||
+    pool.poolType == PoolType.ERC4626Linear
   );
 }
 

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -40,7 +40,7 @@ import {
   ZERO_ADDRESS,
   ZERO_BD,
 } from './helpers/constants';
-import { hasVirtualSupply, isVariableWeightPool, isStableLikePool, PoolType } from './helpers/pools';
+import { hasVirtualSupply, isVariableWeightPool, isStableLikePool, PoolType, isLinearPool } from './helpers/pools';
 import { updateAmpFactor } from './helpers/stable';
 import { PoolCreated, WeightedPoolFactory } from '../types/WeightedPoolFactory/WeightedPoolFactory';
 import { handleNewWeightedPool } from './poolFactory';
@@ -371,9 +371,11 @@ export function handleSwapEvent(event: SwapEvent): void {
   let swapFeesUSD = ZERO_BD;
 
   if (poolAddress != tokenInAddress && poolAddress != tokenOutAddress) {
-    let swapFee = pool.swapFee;
     swapValueUSD = swapValueInUSD(tokenInAddress, tokenAmountIn, tokenOutAddress, tokenAmountOut);
-    swapFeesUSD = swapValueUSD.times(swapFee);
+    if (!isLinearPool(pool)) {
+      let swapFee = pool.swapFee;
+      swapFeesUSD = swapValueUSD.times(swapFee);
+    }
   }
 
   let swapId = transactionHash.toHexString().concat(logIndex.toString());


### PR DESCRIPTION
We're updating information about swap fees earned by the system as if Linear Pools accrued them, but swap fees are only kept in the pool temporarily to pay for rebalancing. It makes more sense to count them as zero.