### PR TITLE
FXPool custom logic for swap fee calculation

### DIFF
--- a/abis/BaseToUsdAssimilator.json
+++ b/abis/BaseToUsdAssimilator.json
@@ -1,0 +1,320 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_baseDecimals",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "_baseToken",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "_quoteToken",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IOracle",
+        "name": "_oracle",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "baseDecimals",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "baseToken",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getRate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "oracle",
+    "outputs": [
+      {
+        "internalType": "contract IOracle",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "usdc",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "viewNumeraireAmount",
+    "outputs": [
+      {
+        "internalType": "int128",
+        "name": "amount_",
+        "type": "int128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "vault",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "poolId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "viewNumeraireAmountAndBalance",
+    "outputs": [
+      {
+        "internalType": "int128",
+        "name": "amount_",
+        "type": "int128"
+      },
+      {
+        "internalType": "int128",
+        "name": "balance_",
+        "type": "int128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "vault",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "poolId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "viewNumeraireBalance",
+    "outputs": [
+      {
+        "internalType": "int128",
+        "name": "balance_",
+        "type": "int128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_baseWeight",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_quoteWeight",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "vault",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "poolId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "viewNumeraireBalanceLPRatio",
+    "outputs": [
+      {
+        "internalType": "int128",
+        "name": "balance_",
+        "type": "int128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "int128",
+        "name": "_amount",
+        "type": "int128"
+      }
+    ],
+    "name": "viewRawAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_baseWeight",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_quoteWeight",
+        "type": "uint256"
+      },
+      {
+        "internalType": "int128",
+        "name": "_amount",
+        "type": "int128"
+      },
+      {
+        "internalType": "address",
+        "name": "vault",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "poolId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "viewRawAmountLPRatio",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "vault",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "poolId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "intakeAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "virtualViewNumeraireBalanceIntake",
+    "outputs": [
+      {
+        "internalType": "int128",
+        "name": "balance_",
+        "type": "int128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "vault",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "poolId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "outputAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "virtualViewNumeraireBalanceOutput",
+    "outputs": [
+      {
+        "internalType": "int128",
+        "name": "balance_",
+        "type": "int128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -1142,4 +1142,6 @@ templates:
       eventHandlers:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
+        - event: AssimilatorIncluded(indexed address,indexed address,indexed address,address)
+          handler: handleAssimilatorIncluded
     

--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -43,6 +43,10 @@ dataSources:
           file: ./abis/StablePool.json
         - name: WeightedPoolFactory
           file: ./abis/WeightedPoolFactory.json
+        - name: FXPool
+          file: ./abis/FXPool.json
+        - name: BaseToUsdAssimilator
+          file: ./abis/BaseToUsdAssimilator.json
       eventHandlers:
         - event: Swap(indexed bytes32,indexed address,indexed address,uint256,uint256)
           handler: handleSwapEvent

--- a/schema.graphql
+++ b/schema.graphql
@@ -96,6 +96,9 @@ type Pool @entity {
   protocolSwapFeeCache: BigDecimal
   protocolYieldFeeCache: BigDecimal
   protocolAumFeeCache: BigDecimal
+
+  # FXPool Only
+  baseAssimilator: Bytes
 }
 
 type PoolToken @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -96,9 +96,6 @@ type Pool @entity {
   protocolSwapFeeCache: BigDecimal
   protocolYieldFeeCache: BigDecimal
   protocolAumFeeCache: BigDecimal
-
-  # FXPool Only
-  baseAssimilator: Bytes
 }
 
 type PoolToken @entity {
@@ -121,6 +118,9 @@ type PoolToken @entity {
 
   # ComposableStablePool Only
   isExemptFromYieldProtocolFee: Boolean
+
+  # FXPool Only
+  assimilator: Bytes
 }
 
 type PriceRateProvider @entity {

--- a/src/mappings/helpers/constants.ts
+++ b/src/mappings/helpers/constants.ts
@@ -57,3 +57,13 @@ function forNetwork(addressByNetwork: AddressByNetwork, network: string): Addres
 }
 
 export let VAULT_ADDRESS = forNetwork(vaultAddressByNetwork, network);
+
+let usdcAddressByNetwork: AddressByNetwork = {
+  mainnet: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  goerli: '0xe0C9275E44Ea80eF17579d33c55136b7DA269aEb',
+  polygon: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174',
+  arbitrum: '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8',
+  dev: '0x0000000000000000000000000000000000000000',
+};
+
+export let USDC_ADDRESS = forNetwork(usdcAddressByNetwork, network);

--- a/src/mappings/helpers/pools.ts
+++ b/src/mappings/helpers/pools.ts
@@ -53,6 +53,10 @@ export function isStableLikePool(pool: Pool): boolean {
   );
 }
 
+export function isFXPool(pool: Pool): boolean {
+  return pool.poolType == PoolType.FX;
+}
+
 export function getPoolAddress(poolId: string): Address {
   return changetype<Address>(Address.fromHexString(poolId.slice(0, 42)));
 }

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -1,4 +1,4 @@
-import { Address, BigDecimal, BigInt, ethereum, log } from '@graphprotocol/graph-ts';
+import { Address, BigDecimal, BigInt, log } from '@graphprotocol/graph-ts';
 import { Transfer } from '../types/templates/WeightedPool/BalancerPoolToken';
 import { OracleEnabledChanged } from '../types/templates/WeightedPool2Tokens/WeightedPool2Tokens';
 import { WeightedPool, SwapFeePercentageChanged } from '../types/templates/WeightedPool/WeightedPool';
@@ -19,6 +19,7 @@ import {
   TokenRateCacheUpdated,
   TokenRateProviderSet,
 } from '../types/templates/StablePhantomPoolV2/ComposableStablePool';
+import { AssimilatorIncluded } from '../types/templates/FXPool/FXPool';
 import { Pool, PriceRateProvider, GradualWeightUpdate, AmpUpdate, SwapFeeUpdate } from '../types/schema';
 
 import {
@@ -409,14 +410,7 @@ export function handleTransfer(event: Transfer): void {
  ************* FXPOOL ***************
  ************************************/
 
-export function handleAssimilatorIncluded(event: ethereum.Event): void {
-  /**
-   * FXPool emits a AssimilatorIncluded event with the following args:
-   *   event.parameters[0] = derivative
-   *   event.parameters[1] = numeraire
-   *   event.parameters[2] = reserve
-   *   event.parameters[3] = assimilator
-   * */
+export function handleAssimilatorIncluded(event: AssimilatorIncluded): void {
   let poolAddress = event.address;
 
   // TODO - refactor so pool -> poolId doesn't require call
@@ -425,10 +419,10 @@ export function handleAssimilatorIncluded(event: ethereum.Event): void {
   let poolIdCall = poolContract.try_getPoolId();
   let poolId = poolIdCall.value;
 
-  let tokenAddress = event.parameters[2].value.toAddress();
+  let tokenAddress = event.params.reserve;
   let poolToken = loadPoolToken(poolId.toHexString(), tokenAddress);
   if (poolToken == null) return;
 
-  poolToken.assimilator = event.parameters[3].value.toAddress();
+  poolToken.assimilator = event.params.assimilator;
   poolToken.save();
 }

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -29,7 +29,7 @@ import {
   loadPriceRateProvider,
   getPoolShare,
 } from './helpers/misc';
-import { ONE_BD, ProtocolFeeType, USDC_ADDRESS, ZERO_ADDRESS, ZERO_BD } from './helpers/constants';
+import { ONE_BD, ProtocolFeeType, ZERO_ADDRESS, ZERO_BD } from './helpers/constants';
 import { updateAmpFactor } from './helpers/stable';
 import { ProtocolFeePercentageCacheUpdated } from '../types/WeightedPoolV2Factory/WeightedPoolV2';
 

--- a/src/mappings/poolController.ts
+++ b/src/mappings/poolController.ts
@@ -417,11 +417,6 @@ export function handleAssimilatorIncluded(event: ethereum.Event): void {
    *   event.parameters[2] = reserve
    *   event.parameters[3] = assimilator
    * */
-  let tokenAddress = event.parameters[2].value.toAddress();
-  if (tokenAddress == USDC_ADDRESS) {
-    return; // skip USDC, we are only interested on base token assimilator
-  }
-
   let poolAddress = event.address;
 
   // TODO - refactor so pool -> poolId doesn't require call
@@ -430,8 +425,10 @@ export function handleAssimilatorIncluded(event: ethereum.Event): void {
   let poolIdCall = poolContract.try_getPoolId();
   let poolId = poolIdCall.value;
 
-  let pool = Pool.load(poolId.toHexString()) as Pool;
-  pool.baseAssimilator = event.parameters[3].value.toAddress();
+  let tokenAddress = event.parameters[2].value.toAddress();
+  let poolToken = loadPoolToken(poolId.toHexString(), tokenAddress);
+  if (poolToken == null) return;
 
-  pool.save();
+  poolToken.assimilator = event.parameters[3].value.toAddress();
+  poolToken.save();
 }

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -50,7 +50,6 @@ import {
   isFXPool,
 } from './helpers/pools';
 import { updateAmpFactor } from './helpers/stable';
-import { FXPool } from '../types/Vault/FXPool';
 import { BaseToUsdAssimilator } from '../types/Vault/BaseToUsdAssimilator';
 
 /************************************

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -388,7 +388,8 @@ export function handleSwapEvent(event: SwapEvent): void {
       swapFeesUSD = swapValueUSD.times(swapFee);
     } else if (isFXPool(pool)) {
       // Custom logic for calculating trading fee for FXPools
-      let baseAssimilator = pool.baseAssimilator;
+      let isTokenInBase = tokenOutAddress == USDC_ADDRESS;
+      let baseAssimilator = isTokenInBase ? poolTokenIn.assimilator : poolTokenOut.assimilator;
       if (baseAssimilator) {
         let assimilatorAddress = Address.fromString(baseAssimilator.toHexString());
         let assimilator = BaseToUsdAssimilator.bind(assimilatorAddress);
@@ -396,7 +397,7 @@ export function handleSwapEvent(event: SwapEvent): void {
 
         if (!rateRes.reverted) {
           let baseRate = scaleDown(rateRes.value, 8);
-          if (tokenOutAddress == USDC_ADDRESS) {
+          if (isTokenInBase) {
             // tokenIn = baseToken, fee = (amountIn * rate) - amountOut
             swapFeesUSD = tokenAmountIn.times(baseRate).minus(tokenAmountOut);
           } else {


### PR DESCRIPTION
At the moment, `Pool.totalSwapFee` for XaveFinance FXPools is displaying 0 on https://thegraph.com/hosted-service/subgraph/balancer-labs/balancer-polygon-v2-beta.

This PR adds the custom logic for the swap fee calculation of XaveFinance FXPools.

For an example result, please refer to this deployment on our subgraph clone - https://thegraph.com/hosted-service/subgraph/xave-finance/balancer-v2-polygon

```
        "totalLiquidity": "1185044.562397210060690128760581697",
        "totalSwapVolume": "1535691.700875",
        "totalSwapFee": "1345.53874049492095".
        "swapsCount": "412"
```