### PR TITLE
Graft arbitrum

### DIFF
--- a/networks.yaml
+++ b/networks.yaml
@@ -168,9 +168,9 @@ polygon:
     startBlock: 32054794
 arbitrum:
   network: arbitrum-one
-  # graft:
-  #   block: 23605789
-  #   base: QmPpDvuEs8qAhFvZR7Be6Snk3knkju2zd3PXZnVeUHsPwe
+  graft:
+    block: 37991130
+    base: QmfXWg4feoambxkeA8RssHqeehhjFP4ALGUQsfYZQPq7iG
   Vault:
     address: "0xBA12222222228d8Ba445958a75a0704d566BF2C8"
     startBlock: 222832


### PR DESCRIPTION
The full sync on Arbitrum is taking too long again. Since the latest changes to `dev` don't have any significant impact to the Arbitrum deployment I'm proposing we graft it to speed things up so we can merge dev to master sooner