### PR TITLE
add aave linear v3 factory

### DIFF
--- a/abis/AaveLinearPoolV3Factory.json
+++ b/abis/AaveLinearPoolV3Factory.json
@@ -1,0 +1,376 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "contract IVault",
+        "name": "vault",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IProtocolFeePercentagesProvider",
+        "name": "protocolFeeProvider",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IBalancerQueries",
+        "name": "queries",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "factoryVersion",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "poolVersion",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "initialPauseWindowDuration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "bufferPeriodDuration",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "protocolId",
+        "type": "uint256"
+      }
+    ],
+    "name": "AaveLinearPoolCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "protocolId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      }
+    ],
+    "name": "AaveLinearPoolProtocolIdRegistered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "FactoryDisabled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "PoolCreated",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "symbol",
+        "type": "string"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "mainToken",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "wrappedToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "upperTarget",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "swapFeePercentage",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "protocolId",
+        "type": "uint256"
+      }
+    ],
+    "name": "create",
+    "outputs": [
+      {
+        "internalType": "contract AaveLinearPool",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "disable",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "selector",
+        "type": "bytes4"
+      }
+    ],
+    "name": "getActionId",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAuthorizer",
+    "outputs": [
+      {
+        "internalType": "contract IAuthorizer",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCreationCode",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCreationCodeContracts",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "contractA",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "contractB",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getLastCreatedPool",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPauseConfiguration",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "pauseWindowDuration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "bufferPeriodDuration",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPoolVersion",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getProtocolFeePercentagesProvider",
+    "outputs": [
+      {
+        "internalType": "contract IProtocolFeePercentagesProvider",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "protocolId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getProtocolName",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getVault",
+    "outputs": [
+      {
+        "internalType": "contract IVault",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isDisabled",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      }
+    ],
+    "name": "isPoolFromFactory",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "protocolId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      }
+    ],
+    "name": "registerProtocolId",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -531,6 +531,39 @@ dataSources:
         - event: PoolCreated(indexed address)
           handler: handleNewAaveLinearPoolV2
   {{/if}}
+  {{#if AaveLinearPoolV3Factory}}
+  - kind: ethereum/contract
+    name: AaveLinearPoolV3Factory
+    network: {{network}}
+    source:
+      address: '{{AaveLinearPoolV3Factory.address}}'
+      abi: AaveLinearPoolV3Factory
+      startBlock: {{AaveLinearPoolV3Factory.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      file: ./src/mappings/poolFactory.ts
+      entities:
+        - Balancer
+        - Pool
+      abis:
+        - name: Vault
+          file: ./abis/Vault.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+        - name: WeightedPool
+          file: ./abis/WeightedPool.json
+        - name: AaveLinearPoolV3Factory
+          file: ./abis/AaveLinearPoolV3Factory.json
+        - name: LinearPool
+          file: ./abis/LinearPool.json
+        - name: AaveLinearPool
+          file: ./abis/AaveLinearPool.json
+      eventHandlers:
+        - event: AaveLinearPoolCreated(indexed address,indexed uint256)
+          handler: handleNewAaveLinearPoolV3
+  {{/if}}
   {{#if ERC4626LinearPoolFactoryBeta}}
   - kind: ethereum/contract
     name: ERC4626LinearPoolFactoryBeta

--- a/networks.yaml
+++ b/networks.yaml
@@ -48,6 +48,9 @@ mainnet:
   AaveLinearPoolV2Factory:
     address: "0x6A0AC04f5C2A10297D5FA79FA6358837a8770041"
     startBlock: 15359085
+  AaveLinearPoolV3Factory:
+    address: "0x7d833FEF5BB92ddb578DA85fc0c35cD5Cc00Fb3e"
+    startBlock: 16136501
   ERC4626LinearPoolFactory:
     address: "0xE061bF85648e9FA7b59394668CfEef980aEc4c66"
     startBlock: 14521506
@@ -98,6 +101,9 @@ goerli:
   AaveLinearPoolV2Factory:
     address: "0xC128468b7Ce63eA702C1f104D55A2566b13D3ABD"
     startBlock: 7421371
+  AaveLinearPoolV3Factory:
+    address: "0x70Bbd023481788e443472e123AB963e5EBF58D06"
+    startBlock: 8094401
   GyroEPoolFactory:
     address: "0x3477fe0444878C168A87459F8167EEF28FCF956c"
     startBlock: 7928618
@@ -148,6 +154,9 @@ polygon:
   AaveLinearPoolV2Factory:
     address: "0x8df6EfEc5547e31B0eb7d1291B511FF8a2bf987c"
     startBlock: 31996915
+  AaveLinearPoolV3Factory:
+    address: "0x35c425234DC42e7402f54cC54573f77842963a56"
+    startBlock: 36555199
   ERC4626LinearPoolFactoryBeta:
     address: "0xC6bD2497332d24094eC16a7261eec5C412B5a2C1"
     startBlock: 25772863
@@ -207,6 +216,9 @@ arbitrum:
   AaveLinearPoolV2Factory:
     address: "0xe2E901AB09f37884BA31622dF3Ca7FC19AA443Be"
     startBlock: 20509414
+  AaveLinearPoolV3Factory:
+    address: "0xa2D801064652A269D92EE2A59F3261155ec66830"
+    startBlock: 44470235
 bnb:
   network: bsc
   Vault:

--- a/schema.graphql
+++ b/schema.graphql
@@ -102,6 +102,9 @@ type Pool @entity {
   protocolSwapFeeCache: BigDecimal
   protocolYieldFeeCache: BigDecimal
   protocolAumFeeCache: BigDecimal
+
+  # AaveLinearV3 Only
+  protocolId: Int
 }
 
 type PoolContract @entity {

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -19,6 +19,7 @@ import { updatePoolWeights } from './helpers/weighted';
 
 import { BigInt, Address, Bytes, BigDecimal, ethereum } from '@graphprotocol/graph-ts';
 import { PoolCreated } from '../types/WeightedPoolFactory/WeightedPoolFactory';
+import { AaveLinearPoolCreated } from '../types/AaveLinearPoolV3Factory/AaveLinearPoolV3Factory';
 import { Balancer, Pool, PoolContract } from '../types/schema';
 
 // datasource
@@ -222,19 +223,23 @@ export function handleNewCCPPool(event: PoolCreated): void {
   CCPoolTemplate.create(poolAddress);
 }
 
-export function handleNewAaveLinearPool(event: PoolCreated): void {
+export function handleNewAaveLinearPool(event: AaveLinearPoolCreated): void {
   handleNewLinearPool(event, PoolType.AaveLinear);
 }
 
-export function handleNewAaveLinearPoolV2(event: PoolCreated): void {
+export function handleNewAaveLinearPoolV2(event: AaveLinearPoolCreated): void {
   handleNewLinearPool(event, PoolType.AaveLinear, 2);
 }
 
-export function handleNewERC4626LinearPool(event: PoolCreated): void {
+export function handleNewAaveLinearPoolV3(event: AaveLinearPoolCreated): void {
+  handleNewLinearPool(event, PoolType.AaveLinear, 2);
+}
+
+export function handleNewERC4626LinearPool(event: AaveLinearPoolCreated): void {
   handleNewLinearPool(event, PoolType.ERC4626Linear);
 }
 
-function handleNewLinearPool(event: PoolCreated, poolType: string, poolTypeVersion: i32 = 1): void {
+function handleNewLinearPool(event: AaveLinearPoolCreated, poolType: string, poolTypeVersion: i32 = 1): void {
   let poolAddress: Address = event.params.pool;
 
   let poolContract = LinearPool.bind(poolAddress);
@@ -249,6 +254,9 @@ function handleNewLinearPool(event: PoolCreated, poolType: string, poolTypeVersi
 
   pool.poolType = poolType;
   pool.poolTypeVersion = poolTypeVersion;
+  if (event.params.protocolId) {
+    pool.protocolId = event.params.protocolId.toI32();
+  }
 
   let mainIndexCall = poolContract.try_getMainIndex();
   pool.mainIndex = mainIndexCall.value.toI32();

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -223,23 +223,37 @@ export function handleNewCCPPool(event: PoolCreated): void {
   CCPoolTemplate.create(poolAddress);
 }
 
-export function handleNewAaveLinearPool(event: AaveLinearPoolCreated): void {
+export function handleNewAaveLinearPool(event: PoolCreated): void {
   handleNewLinearPool(event, PoolType.AaveLinear);
 }
 
-export function handleNewAaveLinearPoolV2(event: AaveLinearPoolCreated): void {
+export function handleNewAaveLinearPoolV2(event: PoolCreated): void {
   handleNewLinearPool(event, PoolType.AaveLinear, 2);
 }
 
 export function handleNewAaveLinearPoolV3(event: AaveLinearPoolCreated): void {
-  handleNewLinearPool(event, PoolType.AaveLinear, 2);
+  const poolCreatedEvent = new PoolCreated(
+    event.address,
+    event.logIndex,
+    event.transactionLogIndex,
+    event.logType,
+    event.block,
+    event.transaction,
+    [event.parameters[0]]
+  );
+  handleNewLinearPool(poolCreatedEvent, PoolType.AaveLinear, 3, event.params.protocolId.toI32());
 }
 
-export function handleNewERC4626LinearPool(event: AaveLinearPoolCreated): void {
+export function handleNewERC4626LinearPool(event: PoolCreated): void {
   handleNewLinearPool(event, PoolType.ERC4626Linear);
 }
 
-function handleNewLinearPool(event: AaveLinearPoolCreated, poolType: string, poolTypeVersion: i32 = 1): void {
+function handleNewLinearPool(
+  event: PoolCreated,
+  poolType: string,
+  poolTypeVersion: i32 = 1,
+  protocolId: i32 = null
+): void {
   let poolAddress: Address = event.params.pool;
 
   let poolContract = LinearPool.bind(poolAddress);
@@ -254,9 +268,7 @@ function handleNewLinearPool(event: AaveLinearPoolCreated, poolType: string, poo
 
   pool.poolType = poolType;
   pool.poolTypeVersion = poolTypeVersion;
-  if (event.params.protocolId) {
-    pool.protocolId = event.params.protocolId.toI32();
-  }
+  pool.protocolId = protocolId;
 
   let mainIndexCall = poolContract.try_getMainIndex();
   pool.mainIndex = mainIndexCall.value.toI32();


### PR DESCRIPTION
Tracks pools from `AaveLineaV3Factory` and adds `protocolId` to `Pool` entity. 

[Demo Subgraph](https://api.thegraph.com/subgraphs/name/mendesfabio/balancer-goerli-v2/graphql?query=%7B%0A%09pools%28%0A++++where%3A+%7B%0A++++++poolType%3A+%22AaveLinear%22%0A++++++poolTypeVersion%3A+3%0A++++++%0A++++%7D%0A++%29+%7B%0A%09++id%0A++++protocolId%0A%09%7D%0A%7D)