### PR TITLE
add index to pool token

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -120,6 +120,7 @@ type PoolToken @entity {
   symbol: String!
   name: String!
   decimals: Int!
+  index: Int!
   address: String!
   priceRate: BigDecimal!
   balance: BigDecimal!

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -100,7 +100,12 @@ export function loadPoolToken(poolId: string, tokenAddress: Address): PoolToken 
   return PoolToken.load(getPoolTokenId(poolId, tokenAddress));
 }
 
-export function createPoolTokenEntity(pool: Pool, tokenAddress: Address, assetManagerAddress: Address): void {
+export function createPoolTokenEntity(
+  pool: Pool,
+  tokenAddress: Address,
+  tokenIndex: i32,
+  assetManagerAddress: Address
+): void {
   let poolTokenId = getPoolTokenId(pool.id, tokenAddress);
 
   let token = ERC20.bind(tokenAddress);
@@ -148,6 +153,7 @@ export function createPoolTokenEntity(pool: Pool, tokenAddress: Address, assetMa
   poolToken.managedBalance = ZERO_BD;
   poolToken.priceRate = ONE_BD;
   poolToken.token = _token.id;
+  poolToken.index = tokenIndex;
 
   if (isComposableStablePool(pool)) {
     let poolAddress = bytesToAddress(pool.address);

--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -517,6 +517,6 @@ function handleNewPoolTokens(pool: Pool, tokens: Bytes[]): void {
 
     if (!assetManager) continue;
 
-    createPoolTokenEntity(pool, tokensAddresses[i], assetManager);
+    createPoolTokenEntity(pool, tokensAddresses[i], i, assetManager);
   }
 }


### PR DESCRIPTION
Adds `index` attribute to `PoolToken` so we can query `pool(id: "0x...") { tokens(orderBy: index) { ... } }` and the list returned will be sorted in the same order as `tokensList` attribute. This is required because the most recent pools deployed changed the ordering of the tokens and now the BPT is always the 1st one -- before all tokens used to be sorted numerically.