### PR TITLE
create base handler for LogArgument event

### DIFF
--- a/abis/EventEmitter.json
+++ b/abis/EventEmitter.json
@@ -1,0 +1,99 @@
+[
+	{
+		"inputs": [],
+		"stateMutability": "nonpayable",
+		"type": "constructor"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": false,
+				"internalType": "address",
+				"name": "sender",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"internalType": "string",
+				"name": "identifier",
+				"type": "string"
+			},
+			{
+				"indexed": false,
+				"internalType": "bytes",
+				"name": "message",
+				"type": "bytes"
+			}
+		],
+		"name": "LogArgument",
+		"type": "event"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "string",
+				"name": "identifier",
+				"type": "string"
+			},
+			{
+				"internalType": "address",
+				"name": "addr",
+				"type": "address"
+			}
+		],
+		"name": "authorize",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "string",
+				"name": "identifier",
+				"type": "string"
+			},
+			{
+				"internalType": "bytes",
+				"name": "message",
+				"type": "bytes"
+			}
+		],
+		"name": "emitEvent",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "string",
+				"name": "identifier",
+				"type": "string"
+			},
+			{
+				"internalType": "address",
+				"name": "addr",
+				"type": "address"
+			}
+		],
+		"name": "removeAuthorization",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "newOwner",
+				"type": "address"
+			}
+		],
+		"name": "transferOwnership",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+	}
+]

--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -9,6 +9,28 @@ repository: https://github.com/balancer-labs/balancer-subgraph-v2
 schema:
   file: ./schema.graphql
 dataSources:
+  {{#if EventEmitter}}
+  - kind: ethereum/contract
+    name: EventEmitter
+    network: {{network}}
+    source:
+      address: '{{EventEmitter.address}}'
+      abi: EventEmitter
+      startBlock: {{EventEmitter.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      file: ./src/mappings/eventEmitter.ts
+      entities:
+        - Pool
+      abis:
+        - name: EventEmitter
+          file: ./abis/EventEmitter.json
+      eventHandlers:
+        - event: LogArgument(address,string,bytes)
+          handler: handleLogArgument
+  {{/if}}
   - kind: ethereum/contract
     name: Vault
     network: {{network}}

--- a/networks.yaml
+++ b/networks.yaml
@@ -62,6 +62,9 @@ mainnet:
     startBlock: 15981805
 goerli:
   network: goerli
+  EventEmitter:
+    address: "0xba898E52644f7A009361Ec5D5FFCb73aC8A9b850"
+    startBlock: 8294218
   Vault:
     address: "0xBA12222222228d8Ba445958a75a0704d566BF2C8"
     startBlock: 4648099
@@ -119,7 +122,7 @@ goerli:
 polygon:
   network: matic
   # graft:
-  #   # The fix to the accounting of token.totalBalanceNotional (PR #342) require that we reindex 
+  #   # The fix to the accounting of token.totalBalanceNotional (PR #342) require that we reindex
   #   # from the start block of the AaveLinearPool with embedded rebalancer
   #   block: 31996915
   #   # always make sure the base subgraph has not been pruned

--- a/src/mappings/eventEmitter.ts
+++ b/src/mappings/eventEmitter.ts
@@ -1,0 +1,26 @@
+import { LogArgument } from '../types/EventEmitter/EventEmitter';
+import { Pool } from '../types/schema';
+
+export function handleLogArgument(event: LogArgument): void {
+  const identifier = event.params.identifier;
+
+  if (identifier == 'setSwapEnabledTrue') {
+    const poolId = event.params.message.toHexString();
+    const pool = Pool.load(poolId);
+
+    if (!pool) return;
+
+    pool.swapEnabled = true;
+    pool.save();
+  }
+
+  if (identifier == 'setSwapEnabledFalse') {
+    const poolId = event.params.message.toHexString();
+    const pool = Pool.load(poolId);
+
+    if (!pool) return;
+
+    pool.swapEnabled = false;
+    pool.save();
+  }
+}


### PR DESCRIPTION
# Description

Adds to PR https://github.com/balancer-labs/balancer-subgraph-v2/pull/351 the handler required to set `swapEnabled` based on `LogArgument` event.

This [query](https://api.thegraph.com/subgraphs/id/QmZr2QvMXEHBi143pxBXfxjL3WTnUZRH48p6VC5MfxLewk/graphql?query=%7B%0A++initialState:+pools(%0A++++block:+%7B%0A++++++number:+8294241%0A++++%7D%0A++)+%7B%0A++++id%0A++++swapEnabled%0A++%7D%0A%09setSwapEnabledFalse:+pools(%0A++++block:+%7B%0A++++++number:+8294242%0A++++%7D%0A++)+%7B%0A++++id%0A++++swapEnabled%0A++%7D%0A++setSwapEnabledTrue:+pools(%0A++++block:+%7B%0A++++++number:+8294372%0A++++%7D%0A++)+%7B%0A++++id%0A++++swapEnabled%0A++%7D%0A%7D) shows it working.