### PR TITLE
Pause window fix

### DIFF
--- a/networks.yaml
+++ b/networks.yaml
@@ -192,9 +192,12 @@ polygon:
     startBlock: 32054793
 arbitrum:
   network: arbitrum-one
-  # graft:
-  #   block: 37991130
-  #   base: QmfXWg4feoambxkeA8RssHqeehhjFP4ALGUQsfYZQPq7iG
+  graft:
+    # One block before we set all pools to recovery mode
+    block: 51220352
+    # always make sure the base subgraph has not been pruned
+    # it should be possible to run time travel queries on it going back to the vault's startBlock
+    base: QmVsBgEoAUgwUXDh1LifikMvffxikNzvHyEp2UeS27TspF
   Vault:
     address: "0xBA12222222228d8Ba445958a75a0704d566BF2C8"
     startBlock: 222832

--- a/networks.yaml
+++ b/networks.yaml
@@ -194,7 +194,7 @@ arbitrum:
   network: arbitrum-one
   graft:
     # One block before we set all pools to recovery mode
-    block: 51220352
+    block: 51220351
     # always make sure the base subgraph has not been pruned
     # it should be possible to run time travel queries on it going back to the vault's startBlock
     base: QmVsBgEoAUgwUXDh1LifikMvffxikNzvHyEp2UeS27TspF

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -120,10 +120,12 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
   }
 
   // if a pool that was paused is joined, it means it's pause has expired
-  if (pool.isPaused) {
-    pool.isPaused = false;
-    pool.swapEnabled = true;
-  }
+  // TODO: fix this for when pool.isPaused is null 
+  // TODO: handle the case where the pool's actual swapEnabled is false
+  // if (pool.isPaused) {
+  //   pool.isPaused = false;
+  //   pool.swapEnabled = true;
+  // }
 
   let tokenAddresses = pool.tokensList;
 
@@ -368,10 +370,12 @@ export function handleSwapEvent(event: SwapEvent): void {
   }
 
   // if a swap happens in a pool that was paused, it means it's pause has expired
-  if (pool.isPaused) {
-    pool.isPaused = false;
-    pool.swapEnabled = true;
-  }
+  // TODO: fix this for when pool.isPaused is null 
+  // TODO: handle the case where the pool's actual swapEnabled is false
+  // if (pool.isPaused) {
+  //   pool.isPaused = false;
+  //   pool.swapEnabled = true;
+  // }
 
   if (isVariableWeightPool(pool)) {
     // Some pools' weights update over time so we need to update them after each swap

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -120,7 +120,7 @@ function handlePoolJoined(event: PoolBalanceChanged): void {
   }
 
   // if a pool that was paused is joined, it means it's pause has expired
-  // TODO: fix this for when pool.isPaused is null 
+  // TODO: fix this for when pool.isPaused is null
   // TODO: handle the case where the pool's actual swapEnabled is false
   // if (pool.isPaused) {
   //   pool.isPaused = false;
@@ -370,7 +370,7 @@ export function handleSwapEvent(event: SwapEvent): void {
   }
 
   // if a swap happens in a pool that was paused, it means it's pause has expired
-  // TODO: fix this for when pool.isPaused is null 
+  // TODO: fix this for when pool.isPaused is null
   // TODO: handle the case where the pool's actual swapEnabled is false
   // if (pool.isPaused) {
   //   pool.isPaused = false;


### PR DESCRIPTION
# Description

The initial implementation of the pause window expiration handler fails for pools where isPaused hasn't been initialized (`isPaused == null`). It was also incorrect for pools that natively support the notion of `swapEnabled`. Since no pools have ever been emergency paused, it's fine to remove this for now so that we quickly deploy this new version of the subgraph bringing back metastable pools.

I've also updated the grafting parameters for Arbitrum because the full sync was taking too long.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas

### Merges to `dev`
- [ ] I have checked that the graft base is not a pruned deployment
