### PR TITLE
Change ERC4626LinearPoolV3 version parameter

### DIFF
--- a/src/mappings/poolFactory.ts
+++ b/src/mappings/poolFactory.ts
@@ -278,7 +278,7 @@ export function handleNewERC4626LinearPoolV3(event: Erc4626LinearPoolCreated): v
     event.transaction,
     [event.parameters[0]]
   );
-  handleNewLinearPool(poolCreatedEvent, PoolType.ERC4626Linear, 3, event.params.protocolId.toI32());
+  handleNewLinearPool(poolCreatedEvent, PoolType.ERC4626Linear, 1, event.params.protocolId.toI32());
 }
 
 export function handleNewEulerLinearPool(event: EulerLinearPoolCreated): void {


### PR DESCRIPTION
from: handleNewLinearPool(poolCreatedEvent, PoolType.ERC4626Linear, 3, event.params.protocolId.toI32());
to: handleNewLinearPool(poolCreatedEvent, PoolType.ERC4626Linear, 1, event.params.protocolId.toI32());

# Description

Please include a summary of the change and if relevant which issue is fixed. Please also include relevant motivation and context.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas

### `dev` -> `master`
- [ ] I have checked that all beta deployments have synced
- [ ] I have checked that the earliest block in the polygon pruned deployment is <insert block number>, <insert block date/time>
  - [ ] The earliest block is more than 24 hours old
- [ ] I have checked that core metrics are the same in the beta and production deployments

### Merges to `dev`
- [ ] I have checked that the graft base is not a pruned deployment
