### PR TITLE
Allow curation contract to set a token's `latestUSDPrice`

### DIFF
--- a/src/mappings/eventEmitter.ts
+++ b/src/mappings/eventEmitter.ts
@@ -1,11 +1,18 @@
 import { LogArgument } from '../types/EventEmitter/EventEmitter';
-import { Pool } from '../types/schema';
+import { Pool, Token } from '../types/schema';
+import { BigDecimal } from '@graphprotocol/graph-ts';
 
 export function handleLogArgument(event: LogArgument): void {
   const identifier = event.params.identifier.toHexString();
 
+  // convention: identifier = keccak256(function_name)
+  // keccak256(setSwapEnabled) = 0xe84220e19c54dd2a96deb4cb59ea58e10e36ae2e5c0887f3af0a1ac8e04b0e29
   if (identifier == '0xe84220e19c54dd2a96deb4cb59ea58e10e36ae2e5c0887f3af0a1ac8e04b0e29') {
     setSwapEnabled(event);
+  }
+  // keccak256(setLatestUSDPrice) = 0x205869a4266a1bbcc5e2e5255221a32636b162e29887138cc0a8ba5141d05c62
+  if (identifier == '0x205869a4266a1bbcc5e2e5255221a32636b162e29887138cc0a8ba5141d05c62') {
+    setLatestUSDPrice(event);
   }
 }
 
@@ -20,4 +27,14 @@ function setSwapEnabled(event: LogArgument): void {
     pool.swapEnabled = true;
   }
   pool.save();
+}
+
+function setLatestUSDPrice(event: LogArgument): void {
+  const tokenAddress = event.params.message.toHexString();
+  const token = Token.load(tokenAddress);
+  if (!token) return;
+
+  const base = BigDecimal.fromString('100');
+  token.latestUSDPrice = (event.params.value.toBigDecimal().div(base);
+  token.save();
 }

--- a/src/mappings/eventEmitter.ts
+++ b/src/mappings/eventEmitter.ts
@@ -17,12 +17,12 @@ export function handleLogArgument(event: LogArgument): void {
 }
 
 function setSwapEnabled(event: LogArgument): void {
-/**
+  /**
    * Sets a pool's swapEnabled attribute
    *
    * @param message - The pool id (eg. 0x12345abce... - all lowercase)
    * @param value - 0 if swapEnabled is to be set false; any other value sets it to true
-   */// 
+   */ //
   const poolId = event.params.message.toHexString();
   const pool = Pool.load(poolId);
   if (!pool) return;
@@ -36,17 +36,17 @@ function setSwapEnabled(event: LogArgument): void {
 }
 
 function setLatestUSDPrice(event: LogArgument): void {
-/**
+  /**
    * Sets a token's latestUSDPrice attribute
    *
    * @param message - The token address (eg. 0x12345abce... - all lowercase)
    * @param value - token price in cents of USD (ie, a value of 1 represents $0.01)
-   */// 
+   */ //
   const tokenAddress = event.params.message.toHexString();
   const token = Token.load(tokenAddress);
   if (!token) return;
 
   const base = BigDecimal.fromString('100');
-  token.latestUSDPrice = (event.params.value.toBigDecimal().div(base));
+  token.latestUSDPrice = event.params.value.toBigDecimal().div(base);
   token.save();
 }

--- a/src/mappings/eventEmitter.ts
+++ b/src/mappings/eventEmitter.ts
@@ -17,6 +17,12 @@ export function handleLogArgument(event: LogArgument): void {
 }
 
 function setSwapEnabled(event: LogArgument): void {
+/**
+   * Sets a pool's swapEnabled attribute
+   *
+   * @param message - The pool id (eg. 0x12345abce... - all lowercase)
+   * @param value - 0 if swapEnabled is to be set false; any other value sets it to true
+   */// 
   const poolId = event.params.message.toHexString();
   const pool = Pool.load(poolId);
   if (!pool) return;
@@ -30,6 +36,12 @@ function setSwapEnabled(event: LogArgument): void {
 }
 
 function setLatestUSDPrice(event: LogArgument): void {
+/**
+   * Sets a token's latestUSDPrice attribute
+   *
+   * @param message - The token address (eg. 0x12345abce... - all lowercase)
+   * @param value - token price in cents of USD (ie, a value of 1 represents $0.01)
+   */// 
   const tokenAddress = event.params.message.toHexString();
   const token = Token.load(tokenAddress);
   if (!token) return;

--- a/src/mappings/eventEmitter.ts
+++ b/src/mappings/eventEmitter.ts
@@ -47,6 +47,6 @@ function setLatestUSDPrice(event: LogArgument): void {
   if (!token) return;
 
   const base = BigDecimal.fromString('100');
-  token.latestUSDPrice = (event.params.value.toBigDecimal().div(base);
+  token.latestUSDPrice = (event.params.value.toBigDecimal().div(base));
   token.save();
 }


### PR DESCRIPTION
# Description

Pools are often mispriced in their early days because tokens in their composition have little swap activity. 

With this PR, parties like the Maxis could update that attribute manually when needed.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Token 0xea010a915915693638ad4fafff632b685e9cf7dd on Polygon should have a latestPriceUSD of:
- 0 at block 39114310
- 0.01 at block 39114311
- 0 at block 39114347

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas