### PR TITLE
fix linear bpt balance

### DIFF
--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -678,8 +678,10 @@ dataSources:
         - name: AaveLinearPool
           file: ./abis/AaveLinearPool.json
       eventHandlers:
-        - event: AaveLinearPoolCreated(indexed address,indexed uint256)
+        - event: PoolCreated(indexed address)
           handler: handleNewAaveLinearPoolV3
+        - event: AaveLinearPoolCreated(indexed address,indexed uint256)
+          handler: handleLinearPoolProtocolId
   {{/if}}
   {{#if ERC4626LinearPoolFactoryBeta}}
   - kind: ethereum/contract
@@ -744,8 +746,10 @@ dataSources:
         - name: EulerLinearPool
           file: ./abis/EulerLinearPool.json
       eventHandlers:
-        - event: EulerLinearPoolCreated(indexed address,indexed uint256)
+        - event: PoolCreated(indexed address)
           handler: handleNewEulerLinearPool
+        - event: EulerLinearPoolCreated(indexed address,indexed uint256)
+          handler: handleLinearPoolProtocolId
   {{/if}}
   {{#if ERC4626LinearPoolFactory}}
   - kind: ethereum/contract
@@ -811,8 +815,10 @@ dataSources:
         - name: ERC4626LinearPoolV3
           file: ./abis/ERC4626LinearPoolV3.json
       eventHandlers:
-        - event: Erc4626LinearPoolCreated(indexed address,indexed uint256)
+        - event: PoolCreated(indexed address)
           handler: handleNewERC4626LinearPoolV3
+        - event: Erc4626LinearPoolCreated(indexed address,indexed uint256)
+          handler: handleLinearPoolProtocolId
   {{/if}}
   {{#if Gyro2PoolFactory}}
   - kind: ethereum/contract


### PR DESCRIPTION
# Description

Linear V3 factories emit the `LinearPoolCreated` event (containing the `protocolId`) after the `PoolBalanceChanged`. Because Subgraph indexes events by log index, the pools don't exist when `handlePoolBalanceChanged` is called and thus the pre-minted BPT amount isn't registered -- leading to a negative value when the LPs start provisioning liquidity.

This PR fixes this by adding a handler for `PoolCreated` event (emitted before `PoolBalanceChanged`) that registers the pool, its tokens, params, etc, on the Subgraph. The `LinearPoolCreated` event is only used to set the `protocolId`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Check if `protocolId`  and `balance` from `PoolToken` is correct [here](https://api.thegraph.com/subgraphs/name/mendesfabio/balancer-v2/graphql?query=%7B%0A%09pools+%7B%0A%09++id%0A++++protocolId%0A++++tokens+%7B%0A++++++symbol%0A++++++balance%0A++++%7D%0A%09%7D%0A%7D) -- this deployment only tracks Euler pools.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas

### Merges to `dev`
- [ ] I have checked that the graft base is not a pruned deployment
