### PR TITLE
add latest deployment factories to goerli

### DIFF
--- a/networks.yaml
+++ b/networks.yaml
@@ -107,6 +107,9 @@ goerli:
   WeightedPoolV2Factory:
     address: "0x94f68b54191F62f781Fe8298A8A5Fa3ed772d227"
     startBlock: 7553858
+  WeightedPoolV3Factory:
+    address: "0x26575A44755E0aaa969FDda1E4291Df22C5624Ea"
+    startBlock: 8456831
   WeightedPool2TokenFactory:
     address: "0xA5bf2ddF098bb0Ef6d120C98217dD6B141c74EE0"
     startBlock: 4716924
@@ -116,6 +119,18 @@ goerli:
   StablePoolV2Factory:
     address: "0xD360B8afb3d7463bE823bE1Ec3c33aA173EbE86e"
     startBlock: 7169381
+  ComposableStablePoolFactory:
+    address: "0xB848f50141F3D4255b37aC288C25C109104F2158"
+    startBlock: 7542764
+  ComposableStablePoolV2Factory:
+    address: "0x85a80afee867aDf27B50BdB7b76DA70f1E853062"
+    startBlock: 8048814
+  ComposableStablePoolV3Factory:
+    address: "0xbfD9769b061E57e478690299011A028194D66e3C"
+    startBlock: 8456835
+  HighAmpComposableStablePoolFactory:
+    address: "0x35802d6f8fe133215E1804EB70748fe39F10F318"
+    startBlock: 7842251
   MetaStablePoolFactory:
     address: "0xA55F73E2281c60206ba43A3590dB07B8955832Be"
     startBlock: 6993057
@@ -131,15 +146,6 @@ goerli:
   StablePhantomPoolFactory:
     address: "0x41E9036AE350baEDCC7107760A020Dca3c0731ec"
     startBlock: 6993896
-  ComposableStablePoolFactory:
-    address: "0xB848f50141F3D4255b37aC288C25C109104F2158"
-    startBlock: 7542764
-  ComposableStablePoolV2Factory:
-    address: "0x85a80afee867aDf27B50BdB7b76DA70f1E853062"
-    startBlock: 8048814
-  HighAmpComposableStablePoolFactory:
-    address: "0x35802d6f8fe133215E1804EB70748fe39F10F318"
-    startBlock: 7842251
   AaveLinearPoolFactory:
     address: "0x94470C12fc192e071F12Fec1152861608CE01562"
     startBlock: 6993887
@@ -152,6 +158,15 @@ goerli:
   AaveLinearPoolV4Factory:
     address: "0x76578ecf9a141296Ec657847fb45B0585bCDa3a6"
     startBlock: 8469020
+  ERC4626LinearPoolFactory:
+    address: "0xdc15A3C5D16413C1C1F75Db0f75c4ae2a4104650"
+    startBlock: 7169160
+  EulerLinearPoolFactory:
+    address: "0x813EE7a840CE909E7Fea2117A44a90b8063bd4fd"
+    startBlock: 8459393
+  ERC4626LinearPoolV3Factory:
+    address: "0xBa240C856498e2d7a70AF4911AaFae0D6b565a5B"
+    startBlock: 8458088
   GyroEPoolFactory:
     address: "0x3477fe0444878C168A87459F8167EEF28FCF956c"
     startBlock: 7928618


### PR DESCRIPTION
# Description

Missing some factories on goerli from the latest set of pool deployments

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [ ] I have commented my code where relevant, particularly in hard-to-understand areas

### `dev` -> `master`
- [ ] I have checked that all beta deployments have synced
- [ ] I have checked that the earliest block in the polygon pruned deployment is <insert block number>, <insert block date/time>
  - [ ] The earliest block is more than 24 hours old
- [ ] I have checked that core metrics are the same in the beta and production deployments

### Merges to `dev`
- [ ] I have checked that the graft base is not a pruned deployment
