### PR TITLE
Deploy metrics hotfix to mainnet staging

### DIFF
--- a/.github/workflows/graph-beta.yml
+++ b/.github/workflows/graph-beta.yml
@@ -28,143 +28,143 @@ jobs:
           graph_subgraph_name: "balancer-v2-beta"
           graph_account: "balancer-labs"
           graph_config_file: "subgraph.yaml"
-  deploy-goerli-beta:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets goerli
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: gtaschuk/graph-deploy@v0.1.12
-        with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-          graph_subgraph_name: "balancer-goerli-v2-beta"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.goerli.yaml"
-  deploy-polygon-beta:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets polygon
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: gtaschuk/graph-deploy@v0.1.12
-        with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-          graph_subgraph_name: "balancer-polygon-v2-beta"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.polygon.yaml"
-  deploy-polygon-prune-beta:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets polygon-prune
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: gtaschuk/graph-deploy@v0.1.12
-        with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-          graph_subgraph_name: "balancer-polygon-prune-v2-beta"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.polygon.yaml"
-  deploy-arbitrum-beta:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets arbitrum
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: gtaschuk/graph-deploy@v0.1.12
-        with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-          graph_subgraph_name: "balancer-arbitrum-v2-beta"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.arbitrum.yaml"
-  deploy-gnosis-beta:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets gnosis
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: gtaschuk/graph-deploy@v0.1.12
-        with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-          graph_subgraph_name: "balancer-gnosis-chain-v2-beta"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.gnosis.yaml"
-  deploy-bnb-beta:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets bnb
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: gtaschuk/graph-deploy@v0.1.12
-        with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-          graph_subgraph_name: "balancer-bnbchain-v2-beta"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.bnb.yaml"
+  # deploy-goerli-beta:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 14
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets goerli
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: gtaschuk/graph-deploy@v0.1.12
+  #       with:
+  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+  #         graph_subgraph_name: "balancer-goerli-v2-beta"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.goerli.yaml"
+  # deploy-polygon-beta:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 14
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets polygon
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: gtaschuk/graph-deploy@v0.1.12
+  #       with:
+  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+  #         graph_subgraph_name: "balancer-polygon-v2-beta"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.polygon.yaml"
+  # deploy-polygon-prune-beta:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 14
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets polygon-prune
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: gtaschuk/graph-deploy@v0.1.12
+  #       with:
+  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+  #         graph_subgraph_name: "balancer-polygon-prune-v2-beta"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.polygon.yaml"
+  # deploy-arbitrum-beta:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 14
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets arbitrum
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: gtaschuk/graph-deploy@v0.1.12
+  #       with:
+  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+  #         graph_subgraph_name: "balancer-arbitrum-v2-beta"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.arbitrum.yaml"
+  # deploy-gnosis-beta:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 14
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets gnosis
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: gtaschuk/graph-deploy@v0.1.12
+  #       with:
+  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+  #         graph_subgraph_name: "balancer-gnosis-chain-v2-beta"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.gnosis.yaml"
+  # deploy-bnb-beta:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 14
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets bnb
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: gtaschuk/graph-deploy@v0.1.12
+  #       with:
+  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+  #         graph_subgraph_name: "balancer-bnbchain-v2-beta"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.bnb.yaml"
 env:
   CI: true

--- a/.github/workflows/graph.yml
+++ b/.github/workflows/graph.yml
@@ -5,29 +5,29 @@ on:
     branches: master
 
 jobs:
-  deploy-goerli:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets goerli
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: gtaschuk/graph-deploy@v0.1.12
-        with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-          graph_subgraph_name: "balancer-goerli-v2"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.goerli.yaml"
+  # deploy-goerli:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 14
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets goerli
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: gtaschuk/graph-deploy@v0.1.12
+  #       with:
+  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+  #         graph_subgraph_name: "balancer-goerli-v2"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.goerli.yaml"
   deploy-mainnet:
     runs-on: ubuntu-latest
     environment: graph
@@ -51,120 +51,120 @@ jobs:
           graph_subgraph_name: "balancer-v2"
           graph_account: "balancer-labs"
           graph_config_file: "subgraph.yaml"
-  deploy-polygon:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets polygon
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: gtaschuk/graph-deploy@v0.1.12
-        with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-          graph_subgraph_name: "balancer-polygon-v2"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.polygon.yaml"
-  deploy-polygon-pruned:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets polygon-prune
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: gtaschuk/graph-deploy@v0.1.12
-        with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-          graph_subgraph_name: "balancer-polygon-prune-v2"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.polygon.yaml"
-  deploy-arbitrum:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets arbitrum
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: gtaschuk/graph-deploy@v0.1.12
-        with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-          graph_subgraph_name: "balancer-arbitrum-v2"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.arbitrum.yaml"
-  deploy-gnosis:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets gnosis
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: gtaschuk/graph-deploy@v0.1.12
-        with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-          graph_subgraph_name: "balancer-gnosis-chain-v2"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.gnosis.yaml"
-  deploy-bnb:
-    runs-on: ubuntu-latest
-    environment: graph
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14
-      - name: Install
-        run: yarn --frozen-lockfile
-      - name: Assets
-        run: yarn generate-assets bnb
-      - name: Codegen
-        run: yarn codegen
-      - name: Build
-        run: yarn build
-      - uses: gtaschuk/graph-deploy@v0.1.12
-        with:
-          graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
-          graph_subgraph_name: "balancer-bnbchain-v2"
-          graph_account: "balancer-labs"
-          graph_config_file: "subgraph.bnb.yaml"
+  # deploy-polygon:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 14
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets polygon
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: gtaschuk/graph-deploy@v0.1.12
+  #       with:
+  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+  #         graph_subgraph_name: "balancer-polygon-v2"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.polygon.yaml"
+  # deploy-polygon-pruned:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 14
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets polygon-prune
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: gtaschuk/graph-deploy@v0.1.12
+  #       with:
+  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+  #         graph_subgraph_name: "balancer-polygon-prune-v2"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.polygon.yaml"
+  # deploy-arbitrum:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 14
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets arbitrum
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: gtaschuk/graph-deploy@v0.1.12
+  #       with:
+  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+  #         graph_subgraph_name: "balancer-arbitrum-v2"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.arbitrum.yaml"
+  # deploy-gnosis:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 14
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets gnosis
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: gtaschuk/graph-deploy@v0.1.12
+  #       with:
+  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+  #         graph_subgraph_name: "balancer-gnosis-chain-v2"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.gnosis.yaml"
+  # deploy-bnb:
+  #   runs-on: ubuntu-latest
+  #   environment: graph
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Install node
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 14
+  #     - name: Install
+  #       run: yarn --frozen-lockfile
+  #     - name: Assets
+  #       run: yarn generate-assets bnb
+  #     - name: Codegen
+  #       run: yarn codegen
+  #     - name: Build
+  #       run: yarn build
+  #     - uses: gtaschuk/graph-deploy@v0.1.12
+  #       with:
+  #         graph_access_token: ${{secrets.GRAPH_ACCESS_TOKEN}}
+  #         graph_subgraph_name: "balancer-bnbchain-v2"
+  #         graph_account: "balancer-labs"
+  #         graph_config_file: "subgraph.bnb.yaml"
 env:
   CI: true

--- a/manifest.template.yaml
+++ b/manifest.template.yaml
@@ -1053,7 +1053,7 @@ dataSources:
         - name: WeightedPool
           file: ./abis/WeightedPool.json
         - name: TetuLinearPoolFactory
-          file: ./abis/TetuLinearPoolFactoryinearPoolFactory.json
+          file: ./abis/TetuLinearPoolFactory.json
         - name: LinearPool
           file: ./abis/LinearPool.json
         - name: TetuLinearPool

--- a/networks.yaml
+++ b/networks.yaml
@@ -1,11 +1,11 @@
 mainnet:
   network: mainnet
   graft:
-    # Jan30 - using this because it's the latest block
-    block: 16521178
+    # Feb11 - Using Aave V3's block since the BPT supply fix goes back to that factory
+    block: 15359085
     # always make sure the base subgraph has not been pruned
     # it should be possible to run time travel queries on it going back to the vault's startBlock
-    base: QmYnU9J6HJ56uGN79F3wo4nG24hVZUNPboSUyje1NvSm68
+    base: QmZfJh2WQAEQRnFfsTK2LrE3LdWS9M7j3T6AeWXHNxLhuK
   EventEmitter:
     address: "0x1ACfEEA57d2ac674d7E65964f155AB9348A6C290"
     startBlock: 16419620
@@ -158,11 +158,11 @@ goerli:
 polygon:
   network: matic
   graft:
-    # Jan30 - using this because it's the latest block
-    block: 38712422
+    # Feb11 - Using Aave V3's block since the BPT supply fix goes back to that factory
+    block: 36555199
     # always make sure the base subgraph has not been pruned
     # it should be possible to run time travel queries on it going back to the vault's startBlock
-    base: QmRpS8GXDmf6Egk4uSmcF4HhwE6UAAqqXMByQgXuvz9jNX
+    base: QmaNhv72Lbq2rGEz9m7EydH3LiyCeDgmDDGzCMRamM8JWe
   EventEmitter:
     address: "0xcdcECFa416EE3022030E707dC3EA13a8997D74c8"
     startBlock: 38152461
@@ -262,11 +262,11 @@ polygon:
 arbitrum:
   network: arbitrum-one
   graft:
-    # Jan30 - using this because it's the latest block
-    block: 56689183
+    # Feb11 - Using Aave V3's block since the BPT supply fix goes back to that factory
+    block: 44470235
     # always make sure the base subgraph has not been pruned
     # it should be possible to run time travel queries on it going back to the vault's startBlock
-    base: QmdLSiv1QcE1pdh236KT5hFfEQ3m1hUMihBKbTb344jwSe
+    base: QmZvXwpwbttRC54f2aAntu7Y97Dg4651k9TZAeJc3DHXoD
   EventEmitter:
     address: "0x8f32D631093B5418d0546f77442c5fa66187E59D"
     startBlock: 53475240

--- a/networks.yaml
+++ b/networks.yaml
@@ -1,11 +1,11 @@
 mainnet:
   network: mainnet
   graft:
-    # This is the block before the issue with the wstETH/ETH StablePool
-    block: 16639809
+    # Picking a block from more than a week ago as a quick way to make sure we get all the recently deployed factories
+    block: 16580891
     # always make sure the base subgraph has not been pruned
     # it should be possible to run time travel queries on it going back to the vault's startBlock
-    base: QmZfJh2WQAEQRnFfsTK2LrE3LdWS9M7j3T6AeWXHNxLhuK
+    base: QmRHmtLuJBXZSJcAEZGnXSpMYuTHgTDw4kRyZK5Zyh97ys
   EventEmitter:
     address: "0x1ACfEEA57d2ac674d7E65964f155AB9348A6C290"
     startBlock: 16419620


### PR DESCRIPTION
# Description

The goal here is to deploy to staging the hotfix that was deployed to the prod mainnet subgraph in #375 and #376.

This will allow us to merge from `dev` to `master` to take advantage of the new factories without breaking the metrics again in prod.

Since deploying the hotfix to Polygon would take too long, I'm commenting out the github workflow so that this only gets deployed to mainnet.

Next steps:
- Merge this PR
- Once mainnet-beta syncs, merge `dev` to `master``
- In `staging-dev`:
  - Comment out mainnet deployment workflows (beta and prod) and uncomment other networks
  - Revert the hotfix
- Merge `staging-dev` to `dev`
  - No new subgraphs should be deployed
- Merge `dev` to `master`
- At this point all networks have all factories but only mainnet has the metrics fix
- Uncomment all deployment workflows and apply the hotfix to `dev` 
- Wait for sync, merge to `master`
- At this point all networks should have the same subgraph version again and we can apply a more definitive fix

## How should this be tested?

Please provide instructions so we can test. Please also list any relevant details for your test configuration.

- [ ] Mainnet beta subgraph metrics look good
- [ ] Mainnet beta subgraph indexes new factories

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have requested at least 1 review (If the PR is significant enough, use best judgement here)
- [x] I have commented my code where relevant, particularly in hard-to-understand areas