### PR TITLE
use immutable entities

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -109,7 +109,7 @@ type Pool @entity {
   protocolId: Int
 }
 
-type PoolContract @entity {
+type PoolContract @entity(immutable: true) {
   id: ID!
   pool: Pool!
 }
@@ -170,7 +170,7 @@ type UserInternalBalance @entity {
   balance: BigDecimal!
 }
 
-type GradualWeightUpdate @entity {
+type GradualWeightUpdate @entity(immutable: true) {
   id: ID!
   poolId: Pool!
   scheduledTimestamp: Int!
@@ -180,7 +180,7 @@ type GradualWeightUpdate @entity {
   endWeights: [BigInt!]!
 }
 
-type AmpUpdate @entity {
+type AmpUpdate @entity(immutable: true) {
   id: ID!
   poolId: Pool!
   scheduledTimestamp: Int!
@@ -190,7 +190,7 @@ type AmpUpdate @entity {
   endAmp: BigInt!
 }
 
-type SwapFeeUpdate @entity {
+type SwapFeeUpdate @entity(immutable: true) {
   id: ID!
   pool: Pool!
   scheduledTimestamp: Int!
@@ -200,7 +200,7 @@ type SwapFeeUpdate @entity {
   endSwapFeePercentage: BigDecimal!
 }
 
-type Swap @entity {
+type Swap @entity(immutable: true) {
   id: ID!
   caller: Bytes!
   tokenIn: Bytes!
@@ -221,7 +221,7 @@ enum InvestType {
   Exit
 }
 
-type JoinExit @entity {
+type JoinExit @entity(immutable: true) {
   id: ID!
   type: InvestType!
   sender: Bytes!
@@ -269,7 +269,7 @@ enum OperationType {
   Update
 }
 
-type ManagementOperation @entity {
+type ManagementOperation @entity(immutable: true) {
   id: ID!
   type: OperationType!
   cashDelta: BigDecimal!


### PR DESCRIPTION
# Description

We have some entities that basically map blockchain events and thus are immutable. This PR annotates this type of entity with `@entity(immutable: true)` in order to make it cheaper for indexers to store this data.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other
