### PR TITLE
prevent sandwich trades from pricing

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -304,6 +304,7 @@ type Token @entity {
   totalSwapCount: BigInt!
   latestPrice: LatestPrice # latest price of token, updated when pool liquidity changes
   latestUSDPrice: BigDecimal # latest price of token in USD, updated when pool liquidity changes
+  latestUSDPriceTimestamp: BigInt # timestamp at which the latestUSDPrice was updated
   latestFXPrice: BigDecimal # latest "off-chain" price of token in USD, only available if token has an offchain price aggregator
   pool: Pool # pool entity associated with the token, if it is a Balancer pool
 }

--- a/src/mappings/helpers/constants.ts
+++ b/src/mappings/helpers/constants.ts
@@ -18,6 +18,9 @@ export const SWAP_OUT = 1;
 
 export let ZERO_ADDRESS = Address.fromString('0x0000000000000000000000000000000000000000');
 
+export let MAX_POS_PRICE_CHANGE = BigDecimal.fromString('1'); // +100%
+export let MAX_NEG_PRICE_CHANGE = BigDecimal.fromString('-0.5'); // -50%%
+
 export let MIN_POOL_LIQUIDITY = BigDecimal.fromString('2000');
 export let MIN_SWAP_VALUE_USD = BigDecimal.fromString('1');
 

--- a/src/mappings/helpers/constants.ts
+++ b/src/mappings/helpers/constants.ts
@@ -18,6 +18,8 @@ export const SWAP_OUT = 1;
 
 export let ZERO_ADDRESS = Address.fromString('0x0000000000000000000000000000000000000000');
 
+export const MAX_TIME_DIFF_FOR_PRICING = BigInt.fromI32(3600); // 1h
+
 export let MAX_POS_PRICE_CHANGE = BigDecimal.fromString('1'); // +100%
 export let MAX_NEG_PRICE_CHANGE = BigDecimal.fromString('-0.5'); // -50%%
 

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -546,7 +546,7 @@ export function handleSwapEvent(event: SwapEvent): void {
 
     tokenPrice.save();
 
-    updateLatestPrice(tokenPrice);
+    updateLatestPrice(tokenPrice, event.block.timestamp);
   }
   if (
     isPricingAsset(tokenOutAddress) &&
@@ -574,7 +574,7 @@ export function handleSwapEvent(event: SwapEvent): void {
 
     tokenPrice.save();
 
-    updateLatestPrice(tokenPrice);
+    updateLatestPrice(tokenPrice, event.block.timestamp);
   }
 
   const preferentialToken = getPreferentialPricingAsset([tokenInAddress, tokenOutAddress]);


### PR DESCRIPTION
# Description

This PR improves the `updateLatestPrice` logic to avoid sandwich trades from setting outlier prices. 

There are 3 possible scenarios here:

1. Subgraph can't estimate the current price in USD - it returns the function;
2. Subgraph can estimate the current price, but it doesn't have a previous one - it sets the estimated price as the latest;
3. Subgraph has both the previous and current price - it calculates the relative change between those values and only updates the price if the change is lower than 100% and greater than -50%. This means that if either the price has increased by 100% or decreased by 50% due to someone manipulating prices, the Subgraph won't update the latest USD price - it still stores the token price in terms of the pricing asset for reference since it doesn't impact metrics.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other
