### PR TITLE
add last post join invariant to composables

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint --max-warnings 0 . --ext .ts",
     "test": "jest ./test/*.test.ts",
     "deploy": "graph deploy balancer-labs/balancer-v2 --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
-    "deploy:local": "graph deploy balancer-labs/balancer-v2 subgraph.dockerParity.yaml --debug --ipfs http://localhost:5001 --node http://127.0.0.1:8020",
+    "deploy:local": "graph deploy balancer-labs/balancer-v2 subgraph.yaml --debug --ipfs http://localhost:5001 --node http://127.0.0.1:8020",
     "import-abis": "ts-node ./scripts/update-abis.ts",
     "generate-assets": "ts-node ./scripts/generate-assets",
     "generate-manifests": "ts-node ./scripts/generate-manifests",

--- a/schema.graphql
+++ b/schema.graphql
@@ -105,6 +105,9 @@ type Pool @entity {
   protocolYieldFeeCache: BigDecimal
   protocolAumFeeCache: BigDecimal
 
+  # Composable Stable Only
+  lastPostJoinExitInvariant: BigDecimal
+
   # AaveLinearV3 Only
   protocolId: Int
 }

--- a/src/mappings/helpers/constants.ts
+++ b/src/mappings/helpers/constants.ts
@@ -10,16 +10,17 @@ export namespace ProtocolFeeType {
   export const Aum = 3;
 }
 
-export let ZERO = BigInt.fromI32(0);
-export let ZERO_BD = BigDecimal.fromString('0');
-export let ONE_BD = BigDecimal.fromString('1');
+export const ZERO = BigInt.fromI32(0);
+export const ONE = BigInt.fromI32(1);
+export const ZERO_BD = BigDecimal.fromString('0');
+export const ONE_BD = BigDecimal.fromString('1');
 export const SWAP_IN = 0;
 export const SWAP_OUT = 1;
 
-export let ZERO_ADDRESS = Address.fromString('0x0000000000000000000000000000000000000000');
+export const ZERO_ADDRESS = Address.fromString('0x0000000000000000000000000000000000000000');
 
-export let MIN_POOL_LIQUIDITY = BigDecimal.fromString('2000');
-export let MIN_SWAP_VALUE_USD = BigDecimal.fromString('1');
+export const MIN_POOL_LIQUIDITY = BigDecimal.fromString('2000');
+export const MIN_SWAP_VALUE_USD = BigDecimal.fromString('1');
 
 export let FX_AGGREGATOR_ADDRESSES = assets.fxAggregators;
 export let FX_TOKEN_ADDRESSES = assets.fxAssets;

--- a/src/mappings/helpers/math.ts
+++ b/src/mappings/helpers/math.ts
@@ -1,0 +1,10 @@
+import { Address, BigInt } from '@graphprotocol/graph-ts';
+import { ZERO, ONE } from './constants';
+
+export function divUp(a: BigInt, b: BigInt): BigInt {
+  if (a.isZero()) {
+    return ZERO;
+  } else {
+    return ONE.plus(a.minus(ONE).div(b));
+  }
+}

--- a/src/mappings/helpers/math.ts
+++ b/src/mappings/helpers/math.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt } from '@graphprotocol/graph-ts';
+import { BigInt } from '@graphprotocol/graph-ts';
 import { ZERO, ONE } from './constants';
 
 export function divUp(a: BigInt, b: BigInt): BigInt {

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -50,7 +50,12 @@ export function scaleDown(num: BigInt, decimals: i32): BigDecimal {
 }
 
 export function scaleUp(num: BigDecimal, decimals: i32): BigInt {
-  return BigInt.fromString(num.times(BigInt.fromI32(10).pow(u8(decimals)).toBigDecimal()).toString());
+  return BigInt.fromString(
+    num
+      .truncate(decimals)
+      .times(BigInt.fromI32(10).pow(u8(decimals)).toBigDecimal())
+      .toString()
+  );
 }
 
 export function getPoolShareId(poolControllerAddress: Address, lpAddress: Address): string {

--- a/src/mappings/helpers/misc.ts
+++ b/src/mappings/helpers/misc.ts
@@ -49,6 +49,10 @@ export function scaleDown(num: BigInt, decimals: i32): BigDecimal {
   return num.divDecimal(BigInt.fromI32(10).pow(u8(decimals)).toBigDecimal());
 }
 
+export function scaleUp(num: BigDecimal, decimals: i32): BigInt {
+  return BigInt.fromString(num.times(BigInt.fromI32(10).pow(u8(decimals)).toBigDecimal()).toString());
+}
+
 export function getPoolShareId(poolControllerAddress: Address, lpAddress: Address): string {
   return poolControllerAddress.toHex().concat('-').concat(lpAddress.toHex());
 }

--- a/src/mappings/helpers/stable.ts
+++ b/src/mappings/helpers/stable.ts
@@ -4,7 +4,7 @@ import { StablePool } from '../../types/templates/StablePool/StablePool';
 import { ZERO, ONE } from './constants';
 import { divUp } from './math';
 
-const AMP_PRECISION = BigInt.fromI32(1000);
+export const AMP_PRECISION = BigInt.fromI32(1000);
 
 export function updateAmpFactor(pool: Pool): void {
   let poolContract = StablePool.bind(changetype<Address>(pool.address));

--- a/src/mappings/helpers/stable.ts
+++ b/src/mappings/helpers/stable.ts
@@ -47,17 +47,20 @@ export function calculateInvariant(amp: BigInt, balances: BigInt[]): BigInt {
 
     prevInvariant = invariant;
 
-    invariant = ampTimesTotal
-      .times(sum)
-      .div(AMP_PRECISION)
-      .plus(D_P.times(BigInt.fromI32(numTokens)).times(invariant));
-    invariant = invariant.div(
-      ampTimesTotal
-        .minus(AMP_PRECISION)
-        .times(invariant)
-        .div(AMP_PRECISION)
-        .plus(BigInt.fromI32(numTokens).plus(ONE).times(D_P))
-    );
+    invariant = invariant
+      .times(
+        ampTimesTotal
+          .times(sum)
+          .div(AMP_PRECISION)
+          .plus(D_P.times(BigInt.fromI32(numTokens)))
+      )
+      .div(
+        ampTimesTotal
+          .minus(AMP_PRECISION)
+          .times(invariant)
+          .div(AMP_PRECISION)
+          .plus(D_P.times(BigInt.fromI32(numTokens).plus(ONE)))
+      );
 
     if (invariant.gt(prevInvariant)) {
       if (invariant.minus(prevInvariant).le(ONE)) {

--- a/src/mappings/helpers/stable.ts
+++ b/src/mappings/helpers/stable.ts
@@ -2,7 +2,6 @@ import { Address, BigInt } from '@graphprotocol/graph-ts';
 import { Pool } from '../../types/schema';
 import { StablePool } from '../../types/templates/StablePool/StablePool';
 import { ZERO, ONE } from './constants';
-import { divUp } from './math';
 
 export const AMP_PRECISION = BigInt.fromI32(1000);
 

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -19,6 +19,7 @@ import {
   tokenToDecimal,
   getTokenPriceId,
   scaleDown,
+  scaleUp,
   createUserEntity,
   getTokenDecimals,
   loadPoolToken,
@@ -58,7 +59,7 @@ import {
   isFXPool,
   isComposableStablePool,
 } from './helpers/pools';
-import { updateAmpFactor } from './helpers/stable';
+import { calculateInvariant, updateAmpFactor } from './helpers/stable';
 import { USDC_ADDRESS } from './helpers/assets';
 
 /************************************
@@ -442,6 +443,39 @@ export function handleSwapEvent(event: SwapEvent): void {
     }
   }
 
+  let newInAmount = poolTokenIn.balance.plus(tokenAmountIn);
+  poolTokenIn.balance = newInAmount;
+  poolTokenIn.save();
+
+  let newOutAmount = poolTokenOut.balance.minus(tokenAmountOut);
+  poolTokenOut.balance = newOutAmount;
+  poolTokenOut.save();
+
+  if (poolAddress == tokenInAddress || poolAddress == tokenOutAddress) {
+    if (isComposableStablePool(pool)) {
+      let tokenAddresses = pool.tokensList;
+      let balances: BigInt[] = [];
+      for (let i: i32 = 0; i < tokenAddresses.length; i++) {
+        let tokenAddress: Address = Address.fromString(tokenAddresses[i].toHexString());
+        if (tokenAddresses[i] == pool.address) {
+          continue;
+        }
+        let poolToken = loadPoolToken(pool.id, tokenAddress);
+        if (poolToken == null) {
+          throw new Error('poolToken not found');
+        }
+        let balance = scaleUp(poolToken.balance, poolToken.decimals);
+        balances.push(balance);
+      }
+      if (pool.amp) {
+        let amp = scaleUp(pool.amp!.toBigDecimal(), 18);
+        let invariantInt = calculateInvariant(amp, balances);
+        let invariant = scaleDown(invariantInt, 18);
+        pool.lastPostJoinExitInvariant = invariant;
+      }
+    }
+  }
+
   let swapId = transactionHash.toHexString().concat(logIndex.toString());
   let swap = new Swap(swapId);
   swap.tokenIn = tokenInAddress;
@@ -482,14 +516,6 @@ export function handleSwapEvent(event: SwapEvent): void {
   vaultSnapshot.totalSwapFee = vault.totalSwapFee;
   vaultSnapshot.totalSwapCount = vault.totalSwapCount;
   vaultSnapshot.save();
-
-  let newInAmount = poolTokenIn.balance.plus(tokenAmountIn);
-  poolTokenIn.balance = newInAmount;
-  poolTokenIn.save();
-
-  let newOutAmount = poolTokenOut.balance.minus(tokenAmountOut);
-  poolTokenOut.balance = newOutAmount;
-  poolTokenOut.save();
 
   // update swap counts for token
   // updates token snapshots as well

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -59,7 +59,7 @@ import {
   isFXPool,
   isComposableStablePool,
 } from './helpers/pools';
-import { calculateInvariant, updateAmpFactor } from './helpers/stable';
+import { calculateInvariant, AMP_PRECISION, updateAmpFactor } from './helpers/stable';
 import { USDC_ADDRESS } from './helpers/assets';
 
 /************************************
@@ -464,11 +464,11 @@ export function handleSwapEvent(event: SwapEvent): void {
         if (poolToken == null) {
           throw new Error('poolToken not found');
         }
-        let balance = scaleUp(poolToken.balance, poolToken.decimals);
+        let balance = scaleUp(poolToken.balance.times(poolToken.priceRate), poolToken.decimals);
         balances.push(balance);
       }
       if (pool.amp) {
-        let amp = scaleUp(pool.amp!.toBigDecimal(), 18);
+        let amp = pool.amp!.times(AMP_PRECISION);
         let invariantInt = calculateInvariant(amp, balances);
         let invariant = scaleDown(invariantInt, 18);
         pool.lastPostJoinExitInvariant = invariant;

--- a/src/mappings/vault.ts
+++ b/src/mappings/vault.ts
@@ -468,6 +468,7 @@ export function handleSwapEvent(event: SwapEvent): void {
         balances.push(balance);
       }
       if (pool.amp) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         let amp = pool.amp!.times(AMP_PRECISION);
         let invariantInt = calculateInvariant(amp, balances);
         let invariant = scaleDown(invariantInt, 18);


### PR DESCRIPTION
# Description

Adds calcs for estimating `lastPostJoinExitInvariant` on Composable pools - h/t mike for this PR.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other
